### PR TITLE
Request authorization headers

### DIFF
--- a/src/loading/binary-loader.ts
+++ b/src/loading/binary-loader.ts
@@ -77,10 +77,7 @@ export class BinaryLoader {
     }
 
     return Promise.resolve(this.getUrl(this.getNodeUrl(node)))
-      .then(url => {
-          // @ts-ignore
-          return this.xhrRequest.bind()(url, { mode: 'cors' });
-      })
+      .then(url => this.xhrRequest(url, { mode: 'cors' }))
       .then(res => res.arrayBuffer())
       .then(buffer => this.parse(node, buffer));
   }

--- a/src/loading/load-poc.ts
+++ b/src/loading/load-poc.ts
@@ -49,8 +49,8 @@ interface POCJson {
 export function loadPOC(url: string, getUrl: GetUrlFn, xhrRequest = fetch): Promise<PointCloudOctreeGeometry> {
   return Promise.resolve(getUrl(url)).then(transformedUrl => {
     return xhrRequest(transformedUrl, { mode: 'cors' })
-      .then(res => res.json())
-      .then(parse(transformedUrl, getUrl, xhrRequest));
+        .then(res => res.json())
+        .then(parse(transformedUrl, getUrl, xhrRequest));
   });
 }
 

--- a/src/loading/types.ts
+++ b/src/loading/types.ts
@@ -1,1 +1,2 @@
 export type GetUrlFn = (url: string) => string | Promise<string>;
+export type XhrRequest = (input: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/point-cloud-octree-geometry-node.ts
+++ b/src/point-cloud-octree-geometry-node.ts
@@ -178,7 +178,10 @@ export class PointCloudOctreeGeometryNode extends EventDispatcher implements IPo
     }
 
     return Promise.resolve(this.pcoGeometry.loader.getUrl(this.getHierarchyUrl()))
-      .then(url => fetch(url, { mode: 'cors' }))
+      .then(url => {
+          // @ts-ignore
+          return this.pcoGeometry.xhrRequest.bind()(url, { mode: 'cors' });
+      })
       .then(res => res.arrayBuffer())
       .then(data => this.loadHierarchy(this, data));
   }

--- a/src/point-cloud-octree-geometry-node.ts
+++ b/src/point-cloud-octree-geometry-node.ts
@@ -178,10 +178,7 @@ export class PointCloudOctreeGeometryNode extends EventDispatcher implements IPo
     }
 
     return Promise.resolve(this.pcoGeometry.loader.getUrl(this.getHierarchyUrl()))
-      .then(url => {
-          // @ts-ignore
-          return this.pcoGeometry.xhrRequest.bind()(url, { mode: 'cors' });
-      })
+      .then(url => this.pcoGeometry.xhrRequest(url, { mode: 'cors' }))
       .then(res => res.arrayBuffer())
       .then(data => this.loadHierarchy(this, data));
   }

--- a/src/point-cloud-octree-geometry.ts
+++ b/src/point-cloud-octree-geometry.ts
@@ -1,5 +1,5 @@
 import { Box3, Vector3 } from 'three';
-import { BinaryLoader } from './loading';
+import { BinaryLoader, XhrRequest } from './loading';
 import { PointAttributes } from './point-attributes';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
 
@@ -22,6 +22,7 @@ export class PointCloudOctreeGeometry {
     public boundingBox: Box3,
     public tightBoundingBox: Box3,
     public offset: Vector3,
+    public xhrRequest: XhrRequest
   ) {}
 
   dispose(): void {

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -1,8 +1,8 @@
 import { Box3, Frustum, Matrix4, PerspectiveCamera, Vector3, WebGLRenderer } from 'three';
 import { DEFAULT_POINT_BUDGET, MAX_LOADS_TO_GPU, MAX_NUM_NODES_LOADING } from './constants';
 import { FEATURES } from './features';
-import {GetUrlFn, loadPOC} from './loading';
-import { ClipMode } from './materials/clipping';
+import { GetUrlFn, loadPOC } from './loading';
+import { ClipMode } from './materials';
 import { PointCloudOctree } from './point-cloud-octree';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
 import { PointCloudOctreeNode } from './point-cloud-octree-node';

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -27,8 +27,8 @@ export class Potree implements IPotree {
   features = FEATURES;
   lru = new LRU(this._pointBudget);
 
-  loadPointCloud(url: string, getUrl: GetUrlFn): Promise<PointCloudOctree> {
-    return loadPOC(url, getUrl).then(geometry => new PointCloudOctree(this, geometry));
+  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest = fetch): Promise<PointCloudOctree> {
+    return loadPOC(url, getUrl, xhrRequest).then(geometry => new PointCloudOctree(this, geometry));
   }
 
   updatePointClouds(

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -1,7 +1,7 @@
 import { Box3, Frustum, Matrix4, PerspectiveCamera, Vector3, WebGLRenderer } from 'three';
 import { DEFAULT_POINT_BUDGET, MAX_LOADS_TO_GPU, MAX_NUM_NODES_LOADING } from './constants';
 import { FEATURES } from './features';
-import { GetUrlFn, loadPOC } from './loading';
+import {GetUrlFn, loadPOC} from './loading';
 import { ClipMode } from './materials/clipping';
 import { PointCloudOctree } from './point-cloud-octree';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
@@ -27,7 +27,8 @@ export class Potree implements IPotree {
   features = FEATURES;
   lru = new LRU(this._pointBudget);
 
-  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest = fetch): Promise<PointCloudOctree> {
+  loadPointCloud(url: string, getUrl: GetUrlFn,
+      xhrRequest = (input: RequestInfo, init?: RequestInit) => fetch(input, init)): Promise<PointCloudOctree> {
     return loadPOC(url, getUrl, xhrRequest).then(geometry => new PointCloudOctree(this, geometry));
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Box3, PerspectiveCamera, Sphere, WebGLRenderer } from 'three';
-import { GetUrlFn } from './loading/types';
+import { GetUrlFn, XhrRequest } from './loading/types';
 import { PointCloudOctree } from './point-cloud-octree';
 import { LRU } from './utils/lru';
 
@@ -31,7 +31,7 @@ export interface IPotree {
   maxNumNodesLoading: number;
   lru: LRU;
 
-  loadPointCloud(url: string, getUrl: GetUrlFn): Promise<PointCloudOctree>;
+  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest: XhrRequest): Promise<PointCloudOctree>;
 
   updatePointClouds(
     pointClouds: PointCloudOctree[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface IPotree {
   maxNumNodesLoading: number;
   lru: LRU;
 
-  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest: XhrRequest): Promise<PointCloudOctree>;
+  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest?: XhrRequest): Promise<PointCloudOctree>;
 
   updatePointClouds(
     pointClouds: PointCloudOctree[],


### PR DESCRIPTION
A possibility to change xhr request headers throughout an arrow function. For instance adding the authorization headers.

``` javascript
return potree.loadPointCloud(path, url => url, (input, init) => {
  setAuthorization(init);
  return fetch(input, init);
});
``` 
or

``` javascript
return potree.loadPointCloud(path, url => url);
```
