### PR TITLE
Revert building the octreeDir path url

### DIFF
--- a/src/loading/load-poc.ts
+++ b/src/loading/load-poc.ts
@@ -79,7 +79,7 @@ function parse(url: string, getUrl: GetUrlFn, xhrRequest: XhrRequest) {
     );
 
     pco.url = url;
-    pco.octreeDir = data.octreeDir;
+    pco.octreeDir = data.octreeDir.indexOf('http') === 0 ? data.octreeDir : `${url}/../${data.octreeDir}`;
     pco.needsUpdate = true;
     pco.spacing = data.spacing;
     pco.hierarchyStepSize = data.hierarchyStepSize;


### PR DESCRIPTION
The condition for building the url is necessary and this is the way how potree.js works.
In the file `point-cloud-octree-geometry-node.ts` there is a method `getHierarchyUrl()` where we create the url based on `this.pcoGeometry.octreeDir`.  The callback (getUrl) from the function `loadPOC` has nothing to do with this and the `transformendUrl` is not used there. @Ailrun I know that it is parsed twice, but there is a problem with loading first `cloud.js` then then the hierarchy file and binaries.