### PR TITLE
Support point picking in special camera systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alejandrodecea/three-loader",
+  "name": "three-loader-fork",
   "private": false,
   "version": "0.0.12",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "@pnext/three-loader",
+  "name": "@alejandrodecea/three-loader",
   "private": false,
   "version": "0.0.12",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
-    "Hugo Campos <hugo.campos@pix4d.com>"
+    "Hugo Campos <hugo.campos@pix4d.com>",
+    "Alejandro de Cea <alejandrodecea@gmail.com>"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "three-loader-fork",
   "private": false,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -399,7 +399,7 @@ export class PointCloudOctree extends PointCloudTree {
 
     const pixelPos = helperVec3; // Use helper vector to prevent extra allocations.
     pixelPos
-      .addVectors(camera.position, ray.direction)
+      .addVectors(ray.origin, ray.direction)
       .project(camera)
       .addScalar(1)
       .multiplyScalar(0.5);


### PR DESCRIPTION
In case you've got something like Three.js's PointerLockControls, the camera's relative position will always be (0, 0, 0), with this change, now it's possible to use the point picking function with such camera systems.