### PR TITLE
Mini-polyfill for Math.sign() for IE11

### DIFF
--- a/src/workers/binary-decoder-worker-internal.ts
+++ b/src/workers/binary-decoder-worker-internal.ts
@@ -12,6 +12,12 @@ import {
 import { Version } from '../version';
 import { CustomArrayView } from './custom-array-view';
 
+// IE11 does not have Math.sign(), this has been adapted from CoreJS es6.math.sign.js for TypeScript
+const mathSign = Math.sign || function(x: number): number {
+  // tslint:disable-next-line:triple-equals
+  return (x = +x) == 0 || x != x ? x : x < 0 ? -1 : 1;
+};
+
 interface DecodedAttribute {
   buffer: ArrayBuffer;
   attribute: IPointAttribute;
@@ -248,8 +254,8 @@ function decodeNormalOct16(attribute: IPointAttribute, ctx: Ctx): DecodedAttribu
       x = u;
       y = v;
     } else {
-      x = -(v / Math.sign(v) - 1) / Math.sign(u);
-      y = -(u / Math.sign(u) - 1) / Math.sign(v);
+      x = -(v / mathSign(v) - 1) / mathSign(u);
+      y = -(u / mathSign(u) - 1) / mathSign(v);
     }
 
     const length = Math.sqrt(x * x + y * y + z * z);


### PR DESCRIPTION
This is adding a polyfill for `Math.sign()` to the web worker to make it work on IE11. This is adapted from https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/math-sign.js. I tried using the polyfill the normal way (including only the `Math.sign()` polyfill) but it increases the worker size from 8 KB to 11 KB which IMHO is a bit much for this one function.

Note that most likely you will still have to polyfill other stuff for the non-web-worker parts of Potree but that can be done by the project that's using Potree. It's just that the web worker cannot be polyfilled from outside because it starts in a pristine JS environment.