### PR TITLE
Fix @requiresShaderUpdate and depth testing

### DIFF
--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -464,15 +464,15 @@ function uniform<K extends keyof IPointCloudMaterialUniforms>(
 
 function requiresShaderUpdate() {
   return (target: Object, propertyKey: string | symbol): void => {
-    let pValue: any;
+    const fieldName = "_" + propertyKey.toString();
 
     Object.defineProperty(target, propertyKey, {
       get() {
-        return pValue;
+        return this[fieldName];
       },
       set(value: any) {
-        if (value !== pValue) {
-          pValue = value;
+        if (value !== this[fieldName]) {
+          this[fieldName] = value;
           this.updateShaderSource();
         }
       },

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -1,7 +1,7 @@
 import {
   AdditiveBlending,
-  AlwaysDepth,
   Color,
+  LessEqualDepth,
   NearestFilter,
   NoBlending,
   RawShaderMaterial,
@@ -262,12 +262,12 @@ export class PointCloudMaterial extends RawShaderMaterial {
       this.transparent = false;
       this.depthTest = true;
       this.depthWrite = true;
+      this.depthFunc = LessEqualDepth;
     } else if (this.opacity < 1.0 && !this.useEDL) {
       this.blending = AdditiveBlending;
       this.transparent = true;
       this.depthTest = false;
       this.depthWrite = true;
-      this.depthFunc = AlwaysDepth;
     }
 
     if (this.weighted) {
@@ -275,6 +275,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
       this.transparent = true;
       this.depthTest = true;
       this.depthWrite = false;
+      this.depthFunc = LessEqualDepth;
     }
 
     this.needsUpdate = true;

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -424,10 +424,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
     if (uObj.type === 'c') {
       (uObj.value as Color).copy(value as Color);
-      this.needsUpdate = true;
     } else if (value !== uObj.value) {
       uObj.value = value;
-      this.needsUpdate = true;
     }
   }
 }

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -178,8 +178,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
     wSourceID: makeUniform('f', 0),
   };
 
-  @uniform('bbSize', true) bbSize!: [number, number, number]; // prettier-ignore
-  @uniform('depthMap', true) depthMap!: Texture | null; // prettier-ignore
+  @uniform('bbSize') bbSize!: [number, number, number]; // prettier-ignore
+  @uniform('depthMap') depthMap!: Texture | null; // prettier-ignore
   @uniform('far') far!: number; // prettier-ignore
   @uniform('fov') fov!: number; // prettier-ignore
   @uniform('heightMax') heightMax!: number; // prettier-ignore
@@ -197,10 +197,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
   @uniform('rgbGamma', true) rgbGamma!: number; // prettier-ignore
   @uniform('screenHeight') screenHeight!: number; // prettier-ignore
   @uniform('screenWidth') screenWidth!: number; // prettier-ignore
-  @uniform('size', true) size!: number; // prettier-ignore
+  @uniform('size') size!: number; // prettier-ignore
   @uniform('spacing') spacing!: number; // prettier-ignore
   @uniform('transition') transition!: number; // prettier-ignore
-  @uniform('uColor', true) color!: Color; // prettier-ignore
+  @uniform('uColor') color!: Color; // prettier-ignore
   @uniform('wClassification') weightClassification!: number; // prettier-ignore
   @uniform('wElevation') weightElevation!: number; // prettier-ignore
   @uniform('wIntensity') weightIntensity!: number; // prettier-ignore

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -122,7 +122,7 @@ export class Potree implements IPotree {
       const pointCloudIndex = queueItem.pointCloudIndex;
       const pointCloud = pointClouds[pointCloudIndex];
 
-      const maxLevel = pointCloud.maxLevel || Infinity;
+      const maxLevel = pointCloud.maxLevel !== undefined ? pointCloud.maxLevel : Infinity;
 
       if (
         node.level > maxLevel ||


### PR DESCRIPTION
These patches fix a few issues we discovered:
* When turning the depth test off and on again (e.g. by adjusting opacity to < 1 and back to 1), the depth comparison function was left at `AlwaysDepth`, effectively disabling the depth test. The `LessEqualDepth` mode has been set in the original Potree code but was missing here.
On the other hand, when depth test is disabled, this and the original code were setting the depth comparison to `AlwaysDepth`, which seems to be unnecessary as it will not be used.
* The `@requiresShaderUpdate` decorator was using the same variable for all instances of the `PointCloudMaterial` class (like a static field). This caused problems with the material for point picking as it was sharing the point color type (among other properties) with the materials for rendering.
* Shaders were recompiled whenever uniforms were changed. This is not necessary, uniforms can be set without recompiling shaders.
* A few uniforms were marked with `requireSrcUpdate = true` but in fact they were not used in `applyDefines()` so they don't change the shader code.
* maxLevel = 0 was treated like unlimited depth although it should be a valid value (i.e. display the root node's points only)
* When shaders are recompiled, uniforms that are set in `onBeforeRender` were not applied reliably (see commit message for more details):
![Bildschirmfoto 2019-03-17 um 22 18 17](https://user-images.githubusercontent.com/429519/54498415-591a3800-4907-11e9-86d3-b926ded9099b.png)
