### PR TITLE
Report MAX_LOADS_TO_GPU throttling, return load promise and errors, fix node size with orthographic camera

### DIFF
--- a/src/potree.ts
+++ b/src/potree.ts
@@ -109,6 +109,7 @@ export class Potree implements IPotree {
     );
 
     let loadedToGPUThisFrame = 0;
+    let exceededMaxLoadsToGPU = false;
     let queueItem: QueueItem | undefined;
 
     while ((queueItem = priorityQueue.pop()) !== undefined) {
@@ -142,6 +143,9 @@ export class Potree implements IPotree {
           node = pointCloud.toTreeNode(node, parentNode);
           loadedToGPUThisFrame++;
         } else {
+          if (node.loaded && loadedToGPUThisFrame >= MAX_LOADS_TO_GPU) {
+            exceededMaxLoadsToGPU = true;
+          }
           unloadedGeometry.push(node);
           pointCloud.visibleGeometry.push(node);
         }
@@ -174,6 +178,7 @@ export class Potree implements IPotree {
     return {
       visibleNodes: visibleNodes,
       numVisiblePoints: numVisiblePoints,
+      exceededMaxLoadsToGPU: exceededMaxLoadsToGPU
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,14 @@ export interface IVisibilityUpdateResult {
    * Make sure to call updatePointClouds() again on the next frame.
    */
   exceededMaxLoadsToGPU: boolean;
+  /**
+   * True when at least one node in view has failed to load.
+   */
+  nodeLoadFailed: boolean;
+  /**
+   * Promises for loading nodes, will reject when loading fails.
+   */
+  nodeLoadPromises: Promise<void>[];
 }
 
 export interface IPotree {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,11 @@ export interface IPointCloudTreeNode {
 export interface IVisibilityUpdateResult {
   visibleNodes: IPointCloudTreeNode[];
   numVisiblePoints: number;
+  /**
+   * True when a node has been loaded but was not added to the scene yet.
+   * Make sure to call updatePointClouds() again on the next frame.
+   */
+  exceededMaxLoadsToGPU: boolean;
 }
 
 export interface IPotree {


### PR DESCRIPTION
* Return whether a node has been deferred to the next frame due to MAX_LOADS_TO_GPU

  This is a simple flag that signals to the caller of updatePointClouds() that the method has to be called again to finish loading of nodes.

* Report failures when loading node data and return node load promises to the caller

  Completing the promise chain to resolve a promise when the web worker has posted back the decoded node. Fix house keeping of the number of loading nodes in case of errors (e.g. 404 on a bin or hrc file).
