### PR TITLE
Fix warnings about unused varyings

### DIFF
--- a/src/materials/shaders/pointcloud.frag
+++ b/src/materials/shaders/pointcloud.frag
@@ -23,15 +23,31 @@ uniform float screenHeight;
 
 uniform sampler2D depthMap;
 
-varying vec3	vColor;
-#ifndef color_type_point_index
+varying vec3 vColor;
+
+#if !defined(color_type_point_index)
 	varying float vOpacity;
 #endif
-varying float	vLinearDepth;
-varying float	vLogDepth;
-varying vec3	vViewPosition;
-varying float	vRadius;
-varying vec3	vNormal;
+
+#if defined(weighted_splats)
+	varying float vLinearDepth;
+#endif
+
+#if !defined(paraboloid_point_shape) && defined(use_edl)
+	varying float vLogDepth;
+#endif
+
+#if defined(color_type_phong) && (MAX_POINT_LIGHTS > 0 || MAX_DIR_LIGHTS > 0) || defined(paraboloid_point_shape)
+	varying vec3 vViewPosition;
+#endif
+
+#if defined(weighted_splats) || defined(paraboloid_point_shape)
+	varying float vRadius;
+#endif
+
+#if defined(color_type_phong) && (MAX_POINT_LIGHTS > 0 || MAX_DIR_LIGHTS > 0)
+	varying vec3 vNormal;
+#endif
 
 float specularStrength = 1.0;
 
@@ -65,13 +81,15 @@ void main() {
 		gl_FragColor = vec4(color, vOpacity);
 	#endif
 
-	vec3 normal = normalize( vNormal );
-	normal.z = abs(normal.z);
-	vec3 viewPosition = normalize( vViewPosition );
-	
 	#if defined(color_type_phong)
+		#if MAX_POINT_LIGHTS > 0 || MAX_DIR_LIGHTS > 0
+			vec3 normal = normalize( vNormal );
+			normal.z = abs(normal.z);
 
-	// code taken from three.js phong light fragment shader
+			vec3 viewPosition = normalize( vViewPosition );
+		#endif
+
+		// code taken from three.js phong light fragment shader
 	
 		#if MAX_POINT_LIGHTS > 0
 


### PR DESCRIPTION
by not declaring them when they would be optimized out.

Observed on Chrome on MacOS with AMD Radeon R9 M370X.