### PR TITLE
Fix node size computation for orthographic cameras

### DIFF
--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -54,6 +54,9 @@ export class PointCloudOctree extends PointCloudTree {
   material: PointCloudMaterial;
   level: number = 0;
   maxLevel: number = Infinity;
+  /**
+   * The minimum radius of a node's bounding sphere on the screen in order to be displayed.
+   */
   minNodePixelSize: number = DEFAULT_MIN_NODE_PIXEL_SIZE;
   root: IPointCloudTreeNode | null = null;
   boundingBoxNodes: Object3D[] = [];

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -225,7 +225,7 @@ export class Potree implements IPotree {
         projectionFactor = halfHeight / (slope * distance);
       } else {
         const orthographic = camera as OrthographicCamera;
-        projectionFactor = radius / orthographic.top;
+        projectionFactor = 2 * halfHeight / (orthographic.top - orthographic.bottom)
       }
 
       const screenPixelRadius = radius * projectionFactor;


### PR DESCRIPTION
Fix node size computation for orthographic cameras

The previous formula was wrong (should have been halfHeight / orthographic.top). I adjusted the formula so it doesn't assume the orthographic camera is symmetric around Y (top != -bottom).
