### PR TITLE
Define MAX_POINT_LIGHTS and MAX_DIR_LIGHTS

### DIFF
--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -335,6 +335,9 @@ export class PointCloudMaterial extends RawShaderMaterial {
       define('use_clip_box');
     }
 
+    define('MAX_POINT_LIGHTS 0');
+    define('MAX_DIR_LIGHTS 0');
+
     parts.push(shaderSrc);
 
     return parts.join('\n');


### PR DESCRIPTION
Otherwise IE11 fails to compile the shader with "syntax error, unexpected IDENT_TOK".

This has been introduced by my changes for https://github.com/pnext/three-loader/pull/38.

This solution is not pretty, but the related code in the shader is dead anyways - required uniforms are not in the material (yet?).