### PR TITLE
Fix clipping-related vertex shader error

### DIFF
--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -496,7 +496,7 @@ void main() {
 
 	#if defined use_clip_box
 		bool insideAny = false;
-		for (int i = 0; i < MAX_CLIP_BOXES; i++) {
+		for (int i = 0; i < max_clip_boxes; i++) {
 			if (i == int(clipBoxCount)) {
 				break;
 			}


### PR DESCRIPTION
- this reference to `max_clip_boxes` was capitalized, resulting in shader errors while attempting to use some of the clipping functionality.