### PR TITLE
[clipping improvements] - new geometry working and 'clip inside' method

### DIFF
--- a/example/main.css
+++ b/example/main.css
@@ -8,6 +8,10 @@ body,
   overflow: hidden;
 }
 
+.gui-container {
+
+}
+
 .btn-container {
   position: absolute;
   bottom: 20px;
@@ -16,4 +20,19 @@ body,
 
 .btn-container button {
   margin-right: 10px;
+}
+
+.slider-container {
+  position: absolute;
+  bottom: 100px;
+  left: 20px;
+}
+
+.slider {
+  margin-right: 10px;
+  width: 200px;
+}
+
+.slider-label {
+  color: white;
 }

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,5 +1,5 @@
-import { Vector3 } from 'three';
-import { PointCloudOctree } from '../src';
+import { Vector3, Matrix4, Box3 } from 'three';
+import { PointCloudOctree, ClipMode, IClipBox, IClipSphere } from '../src';
 import { Viewer } from './viewer';
 
 require('./main.css');
@@ -13,6 +13,11 @@ viewer.initialize(targetEl);
 
 let pointCloud: PointCloudOctree | undefined;
 let loaded: boolean = false;
+
+let clipBox: IClipBox | undefined;
+let clipSphere: IClipSphere | undefined;
+
+let currentTranslation = new Vector3();
 
 const unloadBtn = document.createElement('button');
 unloadBtn.textContent = 'Unload';
@@ -44,6 +49,39 @@ loadBtn.addEventListener('click', () => {
       pointCloud.rotateX(-Math.PI / 2);
       pointCloud.material.size = 1.0;
 
+      pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
+      
+      const min = new Vector3(-1, -1, -1);
+      const max = new Vector3(1, 1, 1);
+      let b = new Box3(min, max);
+      let i = new Matrix4();
+      let m = new Matrix4();
+      let p = new Vector3();
+      const newClipBox = {
+        box: b,
+        matrix: m,
+        inverse: i,
+        position: p,
+      }
+      clipBox = newClipBox;
+      pointCloud.material.setClipBoxes([clipBox]);
+      viewer.addClipBox(clipBox);
+
+      viewer.addAxes();
+
+
+      // clip spheres test
+      const r = 1;
+      const newClipSphere = {
+        radius: r,
+        inverse: i,
+        matrix: m,
+        position: p,
+      }
+      clipSphere = newClipSphere;
+      pointCloud.material.setClipSpheres([clipSphere]);
+      viewer.addClipSphere(clipSphere);
+
       const camera = viewer.camera;
       camera.far = 1000;
       camera.updateProjectionMatrix();
@@ -55,8 +93,76 @@ loadBtn.addEventListener('click', () => {
     .catch(err => console.error(err));
 });
 
+const modeBtn = document.createElement('button');
+modeBtn.textContent = 'Mode';
+modeBtn.addEventListener('click', () => {
+  if (!loaded) {
+    return;
+  }
+  viewer.updateClipMode();
+});
+
+function createSlider(min: string, max: string, startVal: string, id: string, type: string) {
+  const newSlider = document.createElement('input');
+  newSlider.type = 'range';
+  newSlider.step = '0.01';
+  newSlider.min = min;
+  newSlider.max = max;
+  newSlider.value = startVal;
+  newSlider.className = 'slider';
+  newSlider.id = id;
+  newSlider.addEventListener('input', (event) => {
+    if (event.type === 'input') {
+      if (loaded) {
+        if (type === 'x') {
+          currentTranslation.x = parseFloat(newSlider.value);
+          viewer.translateClipBox(currentTranslation, type);
+        } else if (type === 'y') {
+          currentTranslation.y = parseFloat(newSlider.value);
+          viewer.translateClipBox(currentTranslation, type);
+        } else if (type === 'z') {
+          currentTranslation.z = parseFloat(newSlider.value);
+          viewer.translateClipBox(currentTranslation, type);
+        } else if (type === 'scale') {
+          viewer.scaleClipBox(parseFloat(newSlider.value));
+        } else if (type === 'xS') {
+          currentTranslation.x = parseFloat(newSlider.value);
+          viewer.translateClipSphere(currentTranslation, 'x');
+        } else if (type === 'yS') {
+          currentTranslation.y = parseFloat(newSlider.value);
+          viewer.translateClipSphere(currentTranslation, 'y');
+        } else if (type === 'zS') {
+          currentTranslation.z = parseFloat(newSlider.value);
+          viewer.translateClipSphere(currentTranslation, 'z');
+        } else if (type === 'scaleS') {
+          viewer.scaleClipSphere(parseFloat(newSlider.value));
+        } 
+      }
+    }
+  });
+  const newSliderLabel = document.createElement('p');
+  newSliderLabel.className = 'slider-label';
+  newSliderLabel.innerText = type;
+  sliderContainer.appendChild(newSliderLabel);
+  sliderContainer.appendChild(newSlider);
+}
+
 const btnContainer = document.createElement('div');
 btnContainer.className = 'btn-container';
 document.body.appendChild(btnContainer);
 btnContainer.appendChild(unloadBtn);
 btnContainer.appendChild(loadBtn);
+btnContainer.appendChild(modeBtn);
+
+
+const sliderContainer = document.createElement('div');
+sliderContainer.className = 'slider-container';
+document.body.appendChild(sliderContainer);
+createSlider('-5', '5', '0', 'xSlider', 'x');
+createSlider('-5', '5', '0', 'ySlider', 'y');
+createSlider('-5', '5', '0', 'zSlider', 'z');
+createSlider('0.01', '5', '2', 'scaleSlider', 'scale');
+createSlider('-5', '5', '0', 'xSlider', 'xS');
+createSlider('-5', '5', '0', 'ySlider', 'yS');
+createSlider('-5', '5', '0', 'zSlider', 'zS');
+createSlider('0.01', '5', '2', 'scaleSlider', 'scaleS');

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,7 +1,7 @@
 // import { Vector3, Matrix4, Box3 } from 'three';
 import { Vector3, Matrix4 } from 'three';
 // import { PointCloudOctree, ClipMode, IClipBox, IClipSphere, IClipPlane } from '../src';
-import { PointCloudOctree, ClipMode, IClipPlane } from '../src';
+import { PointCloudOctree, ClipMode, IClipBox } from '../src';
 // import { PointCloudOctree, ClipMode } from '../src';
 import { Viewer } from './viewer';
 
@@ -17,10 +17,11 @@ viewer.initialize(targetEl);
 let pointCloud: PointCloudOctree | undefined;
 let loaded: boolean = false;
 
-// let clipBox: IClipBox | undefined;
+let clipBox1: IClipBox | undefined;
+let clipBox2: IClipBox | undefined;
 // let clipSphere: IClipSphere | undefined;
-let clipPlane: IClipPlane | undefined;
-let clipPlane2: IClipPlane | undefined;
+// let clipPlane: IClipPlane | undefined;
+// let clipPlane2: IClipPlane | undefined;
 
 let currentTranslation = new Vector3();
 
@@ -66,14 +67,23 @@ loadBtn.addEventListener('click', () => {
 
       pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
       
-      let m = new Matrix4();
+      let m1 = new Matrix4();
+      let m2 = new Matrix4();
       // CLIP BOXES
-      // const newClipBox = {
-      //   matrix: m,
-      // }
-      // clipBox = newClipBox;
-      //pointCloud.material.setClipBoxes([clipBox]);
-      // viewer.addClipBox(clipBox);
+      const newClipBox1 = {
+        matrix: m1,
+      }
+      clipBox1 = newClipBox1;
+      viewer.addClipBox(clipBox1, 0);
+
+      const newClipBox2 = {
+        matrix: m2,
+      }
+      clipBox2 = newClipBox2;
+      viewer.addClipBox(clipBox2, 1);
+
+
+      pointCloud.material.setClipBoxes([clipBox1, clipBox2]);
 
       // CLIP SPHERE
       // const newClipSphere = {
@@ -84,17 +94,17 @@ loadBtn.addEventListener('click', () => {
       // viewer.addClipSphere(clipSphere);
 
       // CLIP PLANE
-      const newClipPlane = {
-        matrix: m,
-      }
-      const newClipPlane2 = {
-        matrix: m,
-      }
-      clipPlane = newClipPlane;
-      clipPlane2 = newClipPlane2;
-      pointCloud.material.setClipPlanes([clipPlane, clipPlane2]);
-      viewer.addClipPlane(clipPlane);
-      viewer.addClipPlane(clipPlane2);
+      // const newClipPlane = {
+      //   matrix: m,
+      // }
+      // const newClipPlane2 = {
+      //   matrix: m,
+      // }
+      // clipPlane = newClipPlane;
+      // clipPlane2 = newClipPlane2;
+      // pointCloud.material.setClipPlanes([clipPlane, clipPlane2]);
+      // viewer.addClipPlane(clipPlane);
+      // viewer.addClipPlane(clipPlane2);
 
     })
     .catch(err => console.error(err));
@@ -145,10 +155,10 @@ function createSlider(min: string, max: string, startVal: string, id: string, ty
           viewer.scaleClipSphere(parseFloat(newSlider.value));
         } else if (type === 'PZ') {
           currentTranslation.z = parseFloat(newSlider.value);
-          viewer.translateClipPlane(currentTranslation, 'PZ');
+          // viewer.translateClipPlane(currentTranslation, 'PZ');
         } else if (type === 'PR') {
           currentTranslation.z = parseFloat(newSlider.value);
-          viewer.rotateClipPlane(parseFloat(newSlider.value));
+          // viewer.rotateClipPlane(parseFloat(newSlider.value));
         } 
       }
     }
@@ -179,5 +189,5 @@ createSlider('-5', '5', '0', 'xSlider', 'xS');
 createSlider('-5', '5', '0', 'ySlider', 'yS');
 createSlider('-5', '5', '0', 'zSlider', 'zS');
 createSlider('0.01', '5', '2', 'scaleSlider', 'scaleS');
-createSlider('-5', '5', '0', 'planeSlider', 'PZ');
-createSlider('-3.14', '3.14', '0', 'planeSliderR', 'PR');
+// createSlider('-5', '5', '0', 'planeSlider', 'PZ');
+// createSlider('-3.14', '3.14', '0', 'planeSliderR', 'PR');

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,7 +1,7 @@
 // import { Vector3, Matrix4, Box3 } from 'three';
 import { Vector3, Matrix4 } from 'three';
 // import { PointCloudOctree, ClipMode, IClipBox, IClipSphere, IClipPlane } from '../src';
-import { PointCloudOctree, ClipMode, IClipBox } from '../src';
+import { PointCloudOctree, ClipMode, IClipCylinder } from '../src';
 // import { PointCloudOctree, ClipMode } from '../src';
 import { Viewer } from './viewer';
 
@@ -17,11 +17,13 @@ viewer.initialize(targetEl);
 let pointCloud: PointCloudOctree | undefined;
 let loaded: boolean = false;
 
-let clipBox1: IClipBox | undefined;
-let clipBox2: IClipBox | undefined;
+// let clipBox1: IClipBox | undefined;
+// let clipBox2: IClipBox | undefined;
 // let clipSphere: IClipSphere | undefined;
 // let clipPlane: IClipPlane | undefined;
 // let clipPlane2: IClipPlane | undefined;
+let clipCylinder1: IClipCylinder | undefined;
+// let clipCylinder2: IClipCylinder | undefined;
 
 let currentTranslation = new Vector3();
 
@@ -68,22 +70,39 @@ loadBtn.addEventListener('click', () => {
       pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
       
       let m1 = new Matrix4();
-      let m2 = new Matrix4();
-      // CLIP BOXES
-      const newClipBox1 = {
+      // let m2 = new Matrix4();
+
+      // CLIP CYLINDERS
+      const newClipCylinder1 = {
         matrix: m1,
       }
-      clipBox1 = newClipBox1;
-      viewer.addClipBox(clipBox1, 0);
+      clipCylinder1 = newClipCylinder1;
+      viewer.addClipCylinder(clipCylinder1);
 
-      const newClipBox2 = {
-        matrix: m2,
-      }
-      clipBox2 = newClipBox2;
-      viewer.addClipBox(clipBox2, 1);
+      // const newClipCylinder2 = {
+      //   matrix: m2,
+      // }
+      // clipCylinder2 = newClipCylinder2;
+      // viewer.addClipCylinder(clipCylinder2);
 
 
-      pointCloud.material.setClipBoxes([clipBox1, clipBox2]);
+      pointCloud.material.setClipCylinders([clipCylinder1]);
+
+      // CLIP BOXES
+      // const newClipBox1 = {
+      //   matrix: m1,
+      // }
+      // clipBox1 = newClipBox1;
+      // viewer.addClipBox(clipBox1, 0);
+
+      // const newClipBox2 = {
+      //   matrix: m2,
+      // }
+      // clipBox2 = newClipBox2;
+      // viewer.addClipBox(clipBox2, 1);
+
+
+      // pointCloud.material.setClipBoxes([clipBox1, clipBox2]);
 
       // CLIP SPHERE
       // const newClipSphere = {
@@ -133,24 +152,21 @@ function createSlider(min: string, max: string, startVal: string, id: string, ty
       if (loaded) {
         if (type === 'x') {
           currentTranslation.x = parseFloat(newSlider.value);
-          viewer.translateClipBox(currentTranslation, type);
+          viewer.translateClipCylinder(currentTranslation, type);
         } else if (type === 'y') {
           currentTranslation.y = parseFloat(newSlider.value);
-          viewer.translateClipBox(currentTranslation, type);
+          viewer.translateClipCylinder(currentTranslation, type);
         } else if (type === 'z') {
           currentTranslation.z = parseFloat(newSlider.value);
-          viewer.translateClipBox(currentTranslation, type);
+          viewer.translateClipCylinder(currentTranslation, type);
         } else if (type === 'scale') {
-          viewer.scaleClipBox(parseFloat(newSlider.value));
-        } else if (type === 'xS') {
-          currentTranslation.x = parseFloat(newSlider.value);
-          viewer.translateClipSphere(currentTranslation, 'x');
-        } else if (type === 'yS') {
-          currentTranslation.y = parseFloat(newSlider.value);
-          viewer.translateClipSphere(currentTranslation, 'y');
-        } else if (type === 'zS') {
-          currentTranslation.z = parseFloat(newSlider.value);
-          viewer.translateClipSphere(currentTranslation, 'z');
+          viewer.scaleClipCylinder(parseFloat(newSlider.value));
+        } else if (type === 'Rx') {
+          viewer.rotateClipCylinder(parseFloat(newSlider.value), 'x');
+        } else if (type === 'Ry') {
+          viewer.rotateClipCylinder(parseFloat(newSlider.value), 'y');
+        } else if (type === 'Rz') {
+          viewer.rotateClipCylinder(parseFloat(newSlider.value), 'z');
         } else if (type === 'scaleS') {
           viewer.scaleClipSphere(parseFloat(newSlider.value));
         } else if (type === 'PZ') {
@@ -185,9 +201,9 @@ createSlider('-5', '5', '0', 'xSlider', 'x');
 createSlider('-5', '5', '0', 'ySlider', 'y');
 createSlider('-5', '5', '0', 'zSlider', 'z');
 createSlider('0.01', '5', '2', 'scaleSlider', 'scale');
-createSlider('-5', '5', '0', 'xSlider', 'xS');
-createSlider('-5', '5', '0', 'ySlider', 'yS');
-createSlider('-5', '5', '0', 'zSlider', 'zS');
-createSlider('0.01', '5', '2', 'scaleSlider', 'scaleS');
+createSlider('-5', '5', '0', 'xSlider', 'Rx');
+createSlider('-5', '5', '0', 'ySlider', 'Ry');
+createSlider('-5', '5', '0', 'zSlider', 'Rz');
+// createSlider('0.01', '5', '2', 'scaleSlider', 'scaleS');
 // createSlider('-5', '5', '0', 'planeSlider', 'PZ');
 // createSlider('-3.14', '3.14', '0', 'planeSliderR', 'PR');

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,5 +1,8 @@
-import { Vector3, Matrix4, Box3 } from 'three';
-import { PointCloudOctree, ClipMode, IClipBox, IClipSphere } from '../src';
+// import { Vector3, Matrix4, Box3 } from 'three';
+import { Vector3, Matrix4 } from 'three';
+// import { PointCloudOctree, ClipMode, IClipBox, IClipSphere, IClipPlane } from '../src';
+import { PointCloudOctree, ClipMode, IClipPlane } from '../src';
+// import { PointCloudOctree, ClipMode } from '../src';
 import { Viewer } from './viewer';
 
 require('./main.css');
@@ -14,8 +17,10 @@ viewer.initialize(targetEl);
 let pointCloud: PointCloudOctree | undefined;
 let loaded: boolean = false;
 
-let clipBox: IClipBox | undefined;
-let clipSphere: IClipSphere | undefined;
+// let clipBox: IClipBox | undefined;
+// let clipSphere: IClipSphere | undefined;
+let clipPlane: IClipPlane | undefined;
+let clipPlane2: IClipPlane | undefined;
 
 let currentTranslation = new Vector3();
 
@@ -49,38 +54,7 @@ loadBtn.addEventListener('click', () => {
       pointCloud.rotateX(-Math.PI / 2);
       pointCloud.material.size = 1.0;
 
-      pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
-      
-      const min = new Vector3(-1, -1, -1);
-      const max = new Vector3(1, 1, 1);
-      let b = new Box3(min, max);
-      let i = new Matrix4();
-      let m = new Matrix4();
-      let p = new Vector3();
-      const newClipBox = {
-        box: b,
-        matrix: m,
-        inverse: i,
-        position: p,
-      }
-      clipBox = newClipBox;
-      pointCloud.material.setClipBoxes([clipBox]);
-      viewer.addClipBox(clipBox);
-
       viewer.addAxes();
-
-
-      // clip spheres test
-      const r = 1;
-      const newClipSphere = {
-        radius: r,
-        inverse: i,
-        matrix: m,
-        position: p,
-      }
-      clipSphere = newClipSphere;
-      pointCloud.material.setClipSpheres([clipSphere]);
-      viewer.addClipSphere(clipSphere);
 
       const camera = viewer.camera;
       camera.far = 1000;
@@ -89,6 +63,39 @@ loadBtn.addEventListener('click', () => {
       camera.lookAt(new Vector3());
 
       viewer.add(pco);
+
+      pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
+      
+      let m = new Matrix4();
+      // CLIP BOXES
+      // const newClipBox = {
+      //   matrix: m,
+      // }
+      // clipBox = newClipBox;
+      //pointCloud.material.setClipBoxes([clipBox]);
+      // viewer.addClipBox(clipBox);
+
+      // CLIP SPHERE
+      // const newClipSphere = {
+      //   matrix: m,
+      // }
+      // clipSphere = newClipSphere;
+      // pointCloud.material.setClipSpheres([clipSphere]);
+      // viewer.addClipSphere(clipSphere);
+
+      // CLIP PLANE
+      const newClipPlane = {
+        matrix: m,
+      }
+      const newClipPlane2 = {
+        matrix: m,
+      }
+      clipPlane = newClipPlane;
+      clipPlane2 = newClipPlane2;
+      pointCloud.material.setClipPlanes([clipPlane, clipPlane2]);
+      viewer.addClipPlane(clipPlane);
+      viewer.addClipPlane(clipPlane2);
+
     })
     .catch(err => console.error(err));
 });
@@ -136,6 +143,12 @@ function createSlider(min: string, max: string, startVal: string, id: string, ty
           viewer.translateClipSphere(currentTranslation, 'z');
         } else if (type === 'scaleS') {
           viewer.scaleClipSphere(parseFloat(newSlider.value));
+        } else if (type === 'PZ') {
+          currentTranslation.z = parseFloat(newSlider.value);
+          viewer.translateClipPlane(currentTranslation, 'PZ');
+        } else if (type === 'PR') {
+          currentTranslation.z = parseFloat(newSlider.value);
+          viewer.rotateClipPlane(parseFloat(newSlider.value));
         } 
       }
     }
@@ -166,3 +179,5 @@ createSlider('-5', '5', '0', 'xSlider', 'xS');
 createSlider('-5', '5', '0', 'ySlider', 'yS');
 createSlider('-5', '5', '0', 'zSlider', 'zS');
 createSlider('0.01', '5', '2', 'scaleSlider', 'scaleS');
+createSlider('-5', '5', '0', 'planeSlider', 'PZ');
+createSlider('-3.14', '3.14', '0', 'planeSliderR', 'PR');

--- a/example/viewer.ts
+++ b/example/viewer.ts
@@ -1,5 +1,5 @@
 import { PerspectiveCamera, Scene, WebGLRenderer, Vector3, Matrix4 } from 'three';
-import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere} from '../src';
+import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere, IClipPlane, ClipPlane, IClipCylinder, ClipCylinder} from '../src';
 
 // tslint:disable-next-line:no-duplicate-imports
 import * as THREE from 'three';
@@ -51,9 +51,13 @@ export class Viewer {
    */
   private clipSpheres: ClipSphere[] = [];
   /**
-   * Array of clipSpheres which are in the scene and need to be updated.
+   * Array of clipPlanes which are in the scene and need to be updated.
    */
-  // private clipPlanes: ClipPlane[] = [];
+  private clipPlanes: ClipPlane[] = [];
+  /**
+   * Array of clipPlanes which are in the scene and need to be updated.
+   */
+  private clipCylinders: ClipCylinder[] = [];
   /**
    * Initializes the viewer into the specified element.
    *
@@ -162,26 +166,45 @@ export class Viewer {
     this.scene.add(this.clipSpheres[0].mesh);
   }
 
-  // addClipPlane(clipPlane: IClipPlane): void {
-  //   const geometry = new THREE.PlaneGeometry( 5, 20, 32 );
-  //   const material = new THREE.MeshBasicMaterial({
-  //     color: '#ff00ff',
-  //     side: THREE.DoubleSide,
-  //     opacity: 0.25,
-  //     transparent: true, 
-  //   });
-  //   const plane = new THREE.Mesh( geometry, material );
-  //   this.clipPlanes.push({
-  //     iClipPlane: clipPlane,
-  //     geometry: geometry,
-  //     color: '#0000FF',
-  //     mesh: plane,
-  //     position: new THREE.Vector3(0, 0, 0),
-  //     rotation: new THREE.Quaternion(),
-  //     scale: new THREE.Vector3(1, 1, 1),
-  //   });
-  //   this.scene.add(plane);
-  // }
+  addClipPlane(clipPlane: IClipPlane): void {
+    const geometry = new THREE.PlaneGeometry( 5, 20, 32 );
+    const material = new THREE.MeshBasicMaterial({
+      color: '#ff00ff',
+      side: THREE.DoubleSide,
+      opacity: 0.25,
+      transparent: true, 
+    });
+    const plane = new THREE.Mesh( geometry, material );
+    this.clipPlanes.push({
+      iClipPlane: clipPlane,
+      geometry: geometry,
+      color: '#0000FF',
+      mesh: plane,
+      position: new THREE.Vector3(0, 0, 0),
+      rotation: new THREE.Quaternion(),
+      scale: new THREE.Vector3(1, 1, 1),
+    });
+    this.scene.add(plane);
+  }
+
+  addClipCylinder(clipCylinder: IClipCylinder): void {
+    const geometry = new THREE.CylinderGeometry( 1, 1, 1, 32 );
+    const material = new THREE.MeshBasicMaterial({
+      color: '#ff00ff',
+      wireframe: true,
+    });
+    const cylinder = new THREE.Mesh( geometry, material );
+    this.clipCylinders.push({
+      iClipCylinder: clipCylinder,
+      geometry: geometry,
+      color: '#0000FF',
+      mesh: cylinder,
+      position: new THREE.Vector3(0, 0, 0),
+      rotation: new THREE.Quaternion(),
+      scale: new THREE.Vector3(1, 1, 1),
+    });
+    this.scene.add(cylinder);
+  }
 
   updateClipMode() {
     const pcos = this.pointClouds;
@@ -271,65 +294,123 @@ export class Viewer {
     this.pointClouds[0].material.setClipSpheres([iClipSphere]);
   }
 
-  // translateClipPlane = (translation: Vector3, axis: string) => {
-  //   const currentPos = this.clipPlanes[0].position;
-  //   if (axis === 'x') {
-  //     this.clipPlanes[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
-  //   } else if (axis === 'y') {
-  //     this.clipPlanes[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
-  //   } else if (axis === 'PZ') {
-  //     this.clipPlanes[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
-  //   }
+  translateClipPlane = (translation: Vector3, axis: string) => {
+    const currentPos = this.clipPlanes[0].position;
+    if (axis === 'x') {
+      this.clipPlanes[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
+    } else if (axis === 'y') {
+      this.clipPlanes[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
+    } else if (axis === 'PZ') {
+      this.clipPlanes[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
+    }
     
-  //   this.clipPlanes[0].mesh.position.set(this.clipPlanes[0].position.x, this.clipPlanes[0].position.y, this.clipPlanes[0].position.z);
+    this.clipPlanes[0].mesh.position.set(this.clipPlanes[0].position.x, this.clipPlanes[0].position.y, this.clipPlanes[0].position.z);
 
-  //   let iClipPlane = this.clipPlanes[0].iClipPlane;
-  //   const m = new Matrix4();
-  //   m.compose(
-  //     this.clipPlanes[0].position,
-  //     this.clipPlanes[0].rotation,
-  //     this.clipPlanes[0].scale,
-  //   );
-  //   iClipPlane.matrix.getInverse(m);
-  //   console.log(iClipPlane.matrix);
+    let iClipPlane = this.clipPlanes[0].iClipPlane;
+    const m = new Matrix4();
+    m.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane.matrix.getInverse(m);
+    console.log(iClipPlane.matrix);
 
-  //   let iClipPlane2 = this.clipPlanes[1].iClipPlane;
-  //   const m2 = new Matrix4();
-  //   m2.compose(
-  //     this.clipPlanes[0].position,
-  //     this.clipPlanes[0].rotation,
-  //     this.clipPlanes[0].scale,
-  //   );
-  //   iClipPlane2.matrix.getInverse(m2);
+    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+    const m2 = new Matrix4();
+    m2.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane2.matrix.getInverse(m2);
 
-  //   this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane]);
-  // }
+    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane]);
+  }
 
-  // rotateClipPlane = (rotationAngle: number) => {
-  //   this.clipPlanes[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
-  //   let newEuler = new THREE.Euler();
-  //   newEuler.setFromQuaternion(this.clipPlanes[0].rotation);
-  //   this.clipPlanes[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
-  //   let iClipPlane = this.clipPlanes[0].iClipPlane;
-  //   const m = new Matrix4;
-  //   m.compose(
-  //     this.clipPlanes[0].position,
-  //     this.clipPlanes[0].rotation,
-  //     this.clipPlanes[0].scale,
-  //   );
-  //   iClipPlane.matrix.getInverse(m);
+  rotateClipPlane = (rotationAngle: number) => {
+    this.clipPlanes[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
+    let newEuler = new THREE.Euler();
+    newEuler.setFromQuaternion(this.clipPlanes[0].rotation);
+    this.clipPlanes[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
+    let iClipPlane = this.clipPlanes[0].iClipPlane;
+    const m = new Matrix4;
+    m.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane.matrix.getInverse(m);
 
-  //   let iClipPlane2 = this.clipPlanes[1].iClipPlane;
-  //   const m2 = new Matrix4;
-  //   m2.compose(
-  //     this.clipPlanes[1].position,
-  //     this.clipPlanes[1].rotation,
-  //     this.clipPlanes[1].scale,
-  //   );
-  //   iClipPlane2.matrix.getInverse(m2);
+    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+    const m2 = new Matrix4;
+    m2.compose(
+      this.clipPlanes[1].position,
+      this.clipPlanes[1].rotation,
+      this.clipPlanes[1].scale,
+    );
+    iClipPlane2.matrix.getInverse(m2);
 
-  //   this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane2]);
-  // }
+    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane2]);
+  }
+
+  translateClipCylinder = (translation: Vector3, axis: string) => {
+    const currentPos = this.clipCylinders[0].position;
+    if (axis === 'x') {
+      this.clipCylinders[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
+    } else if (axis === 'y') {
+      this.clipCylinders[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
+    } else if (axis === 'z') {
+      this.clipCylinders[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
+    }
+    this.clipCylinders[0].mesh.position.set(this.clipCylinders[0].position.x, this.clipCylinders[0].position.y, this.clipCylinders[0].position.z);
+
+    let iClipCylinder = this.clipCylinders[0].iClipCylinder;
+    const m = new Matrix4();
+    m.compose(
+      this.clipCylinders[0].position,
+      this.clipCylinders[0].rotation,
+      this.clipCylinders[0].scale,
+    );
+    iClipCylinder.matrix.getInverse(m);
+    this.pointClouds[0].material.setClipCylinders([iClipCylinder]);
+  }
+
+  scaleClipCylinder = (scale: number) => {
+    this.clipCylinders[0].scale = new Vector3(1, scale, 1);
+    this.clipCylinders[0].mesh.scale.set(this.clipCylinders[0].scale.x, this.clipCylinders[0].scale.y, this.clipCylinders[0].scale.z);
+    let iClipCylinder = this.clipCylinders[0].iClipCylinder;
+    const m = new Matrix4;
+    m.compose(
+      this.clipCylinders[0].position,
+      this.clipCylinders[0].rotation,
+      this.clipCylinders[0].scale,
+    )
+    iClipCylinder.matrix.getInverse(m);
+    this.pointClouds[0].material.setClipCylinders([iClipCylinder]);
+  }
+
+  rotateClipCylinder = (rotationAngle: number, axis: string) => {
+    if (axis === 'x') {
+      this.clipCylinders[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
+    } else if (axis === 'y') {
+      this.clipCylinders[0].rotation.setFromAxisAngle(new Vector3(0, 1, 0), rotationAngle);
+    } else if (axis === 'z') {
+      this.clipCylinders[0].rotation.setFromAxisAngle(new Vector3(0, 0, 1), rotationAngle);
+    }
+    let newEuler = new THREE.Euler();
+    newEuler.setFromQuaternion(this.clipCylinders[0].rotation);
+    this.clipCylinders[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
+    let iClipCylinder = this.clipCylinders[0].iClipCylinder;
+    const m = new Matrix4;
+    m.compose(
+      this.clipCylinders[0].position,
+      this.clipCylinders[0].rotation,
+      this.clipCylinders[0].scale,
+    );
+    iClipCylinder.matrix.getInverse(m);
+    this.pointClouds[0].material.setClipCylinders([iClipCylinder]);
+  }
 
   addAxes() {
     this.addAxis(new THREE.Vector3(-10, 0, 0), new THREE.Vector3(10, 0, 0), '#FF0000');

--- a/example/viewer.ts
+++ b/example/viewer.ts
@@ -1,5 +1,5 @@
 import { PerspectiveCamera, Scene, WebGLRenderer, Vector3, Matrix4 } from 'three';
-import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere } from '../src';
+import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere, IClipPlane, ClipPlane } from '../src';
 
 // tslint:disable-next-line:no-duplicate-imports
 import * as THREE from 'three';
@@ -51,6 +51,10 @@ export class Viewer {
    */
   private clipSpheres: ClipSphere[] = [];
   /**
+   * Array of clipSpheres which are in the scene and need to be updated.
+   */
+  private clipPlanes: ClipPlane[] = [];
+  /**
    * Initializes the viewer into the specified element.
    *
    * @param targetEl
@@ -63,6 +67,9 @@ export class Viewer {
 
     this.targetEl = targetEl;
     targetEl.appendChild(this.renderer.domElement);
+
+    // ELLIOTT EXPERIMENT WITH RENDERER CLIPPING PLANES
+    this.renderer.localClippingEnabled = true;
 
     this.cameraControls = new OrbitControls(this.camera, this.targetEl);
 
@@ -113,16 +120,14 @@ export class Viewer {
   }
 
   addClipBox(clipBox: IClipBox): void {
-    const clipBoxBox3 = clipBox.box;
-    const min = clipBoxBox3.min;
-    const max = clipBoxBox3.min;
-    const geometry = new THREE.BoxGeometry(max.x-min.x, max.y-min.y, max.z-min.z);
-    const material = new THREE.MeshBasicMaterial({
-      color: 0x00ff00,
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshLambertMaterial({
+      color: '#00ff00',
+      opacity: 0.25,
+      transparent: true, 
       wireframe: true,
     });
     const cube = new THREE.Mesh( geometry, material );
-    cube.position.set(clipBox.position.x, clipBox.position.y, clipBox.position.z);
     this.clipBoxes.push({
       iClipBox: clipBox,
       geometry: geometry,
@@ -136,7 +141,7 @@ export class Viewer {
   }
 
   addClipSphere(clipSphere: IClipSphere): void {
-    const geometry = new THREE.SphereGeometry(clipSphere.radius, 32, 32);
+    const geometry = new THREE.SphereGeometry(1, 32, 32);
     const material = new THREE.MeshLambertMaterial({ 
       color: '#0000ff',
       opacity: 0.25,
@@ -156,14 +161,37 @@ export class Viewer {
     this.scene.add(this.clipSpheres[0].mesh);
   }
 
+  addClipPlane(clipPlane: IClipPlane): void {
+    const geometry = new THREE.PlaneGeometry( 5, 20, 32 );
+    const material = new THREE.MeshBasicMaterial({
+      color: '#ff00ff',
+      side: THREE.DoubleSide,
+      opacity: 0.25,
+      transparent: true, 
+    });
+    const plane = new THREE.Mesh( geometry, material );
+    this.clipPlanes.push({
+      iClipPlane: clipPlane,
+      geometry: geometry,
+      color: '#0000FF',
+      mesh: plane,
+      position: new THREE.Vector3(0, 0, 0),
+      rotation: new THREE.Quaternion(),
+      scale: new THREE.Vector3(1, 1, 1),
+    });
+    this.scene.add(plane);
+  }
+
   updateClipMode() {
     const pcos = this.pointClouds;
     const numPcos = pcos.length;
     if (numPcos > 0) {
       const pointCloud = pcos[0];
       if (pointCloud.material.clipMode === ClipMode.HIGHLIGHT_INSIDE) {
-        pointCloud.material.clipMode = ClipMode.CLIP_OUTSIDE_TEST;
-      } else if (pointCloud.material.clipMode === ClipMode.CLIP_OUTSIDE_TEST) {
+        pointCloud.material.clipMode = ClipMode.CLIP_OUTSIDE;
+      } else if (pointCloud.material.clipMode === ClipMode.CLIP_OUTSIDE) {
+        pointCloud.material.clipMode = ClipMode.CLIP_INSIDE;
+      } else if (pointCloud.material.clipMode === ClipMode.CLIP_INSIDE) {
         pointCloud.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
       }
     }
@@ -181,28 +209,28 @@ export class Viewer {
     
     this.clipBoxes[0].mesh.position.set(this.clipBoxes[0].position.x, this.clipBoxes[0].position.y, this.clipBoxes[0].position.z);
 
+    let iClipBox = this.clipBoxes[0].iClipBox;
     const m = new Matrix4;
     m.compose(
       this.clipBoxes[0].position,
       this.clipBoxes[0].rotation,
       this.clipBoxes[0].scale,
     );
-    let iClipBox = this.clipBoxes[0].iClipBox;
-    iClipBox.inverse.getInverse(m);
+    iClipBox.matrix.getInverse(m);
     this.pointClouds[0].material.setClipBoxes([iClipBox]);
   }
 
   scaleClipBox = (scale: number) => {
     this.clipBoxes[0].scale = new Vector3(scale, scale, scale);
     this.clipBoxes[0].mesh.scale.set(this.clipBoxes[0].scale.x, this.clipBoxes[0].scale.y, this.clipBoxes[0].scale.z);
+    let iClipBox = this.clipBoxes[0].iClipBox;
     const m = new Matrix4;
     m.compose(
       this.clipBoxes[0].position,
       this.clipBoxes[0].rotation,
       this.clipBoxes[0].scale,
     )
-    let iClipBox = this.clipBoxes[0].iClipBox;
-    iClipBox.inverse.getInverse(m);
+    iClipBox.matrix.getInverse(m);
     this.pointClouds[0].material.setClipBoxes([iClipBox]);
   }
 
@@ -217,30 +245,89 @@ export class Viewer {
     }
     
     this.clipSpheres[0].mesh.position.set(this.clipSpheres[0].position.x, this.clipSpheres[0].position.y, this.clipSpheres[0].position.z);
-
+    let iClipSphere = this.clipSpheres[0].iClipSphere;
     const m = new Matrix4;
     m.compose(
       this.clipSpheres[0].position,
       this.clipSpheres[0].rotation,
       this.clipSpheres[0].scale,
     );
-    let iClipSphere = this.clipSpheres[0].iClipSphere;
-    iClipSphere.inverse.getInverse(m);
+    iClipSphere.matrix.getInverse(m); 
     this.pointClouds[0].material.setClipSpheres([iClipSphere]);
   }
 
   scaleClipSphere = (scale: number) => {
     this.clipSpheres[0].scale = new Vector3(scale, scale, scale);
     this.clipSpheres[0].mesh.scale.set(this.clipSpheres[0].scale.x, this.clipSpheres[0].scale.y, this.clipSpheres[0].scale.z);
+    let iClipSphere = this.clipSpheres[0].iClipSphere;
     const m = new Matrix4;
     m.compose(
       this.clipSpheres[0].position,
       this.clipSpheres[0].rotation,
       this.clipSpheres[0].scale,
     )
-    let iClipSphere = this.clipSpheres[0].iClipSphere;
-    iClipSphere.inverse.getInverse(m);
+    iClipSphere.matrix.getInverse(m);
     this.pointClouds[0].material.setClipSpheres([iClipSphere]);
+  }
+
+  translateClipPlane = (translation: Vector3, axis: string) => {
+    const currentPos = this.clipPlanes[0].position;
+    if (axis === 'x') {
+      this.clipPlanes[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
+    } else if (axis === 'y') {
+      this.clipPlanes[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
+    } else if (axis === 'PZ') {
+      this.clipPlanes[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
+    }
+    
+    this.clipPlanes[0].mesh.position.set(this.clipPlanes[0].position.x, this.clipPlanes[0].position.y, this.clipPlanes[0].position.z);
+
+    let iClipPlane = this.clipPlanes[0].iClipPlane;
+    const m = new Matrix4();
+    m.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane.matrix.getInverse(m);
+    console.log(iClipPlane.matrix);
+
+    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+    const m2 = new Matrix4();
+    m2.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane2.matrix.getInverse(m2);
+
+    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane]);
+  }
+
+  rotateClipPlane = (rotationAngle: number) => {
+    this.clipPlanes[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
+    let newEuler = new THREE.Euler();
+    newEuler.setFromQuaternion(this.clipPlanes[0].rotation);
+    this.clipPlanes[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
+    let iClipPlane = this.clipPlanes[0].iClipPlane;
+    const m = new Matrix4;
+    m.compose(
+      this.clipPlanes[0].position,
+      this.clipPlanes[0].rotation,
+      this.clipPlanes[0].scale,
+    );
+    iClipPlane.matrix.getInverse(m);
+
+    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+    const m2 = new Matrix4;
+    m2.compose(
+      this.clipPlanes[1].position,
+      this.clipPlanes[1].rotation,
+      this.clipPlanes[1].scale,
+    );
+    iClipPlane2.matrix.getInverse(m2);
+
+    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane2]);
   }
 
   addAxes() {

--- a/example/viewer.ts
+++ b/example/viewer.ts
@@ -1,5 +1,5 @@
 import { PerspectiveCamera, Scene, WebGLRenderer, Vector3, Matrix4 } from 'three';
-import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere, IClipPlane, ClipPlane } from '../src';
+import { PointCloudOctree, Potree, ClipMode, IClipBox, ClipBox, IClipSphere, ClipSphere} from '../src';
 
 // tslint:disable-next-line:no-duplicate-imports
 import * as THREE from 'three';
@@ -53,7 +53,7 @@ export class Viewer {
   /**
    * Array of clipSpheres which are in the scene and need to be updated.
    */
-  private clipPlanes: ClipPlane[] = [];
+  // private clipPlanes: ClipPlane[] = [];
   /**
    * Initializes the viewer into the specified element.
    *
@@ -119,7 +119,7 @@ export class Viewer {
     this.pointClouds.push(pco);
   }
 
-  addClipBox(clipBox: IClipBox): void {
+  addClipBox(clipBox: IClipBox, index: number): void {
     const geometry = new THREE.BoxGeometry(1, 1, 1);
     const material = new THREE.MeshLambertMaterial({
       color: '#00ff00',
@@ -128,16 +128,17 @@ export class Viewer {
       wireframe: true,
     });
     const cube = new THREE.Mesh( geometry, material );
+    cube.position.set(index, index, index);
     this.clipBoxes.push({
       iClipBox: clipBox,
       geometry: geometry,
       color: '#00FF00',
       mesh: cube,
-      position: new THREE.Vector3(0, 0, 0),
+      position: new THREE.Vector3(index, index, index),
       rotation: new THREE.Quaternion,
       scale: new THREE.Vector3(1, 1, 1),
     });
-    this.scene.add(this.clipBoxes[0].mesh);
+    this.scene.add(this.clipBoxes[index].mesh);
   }
 
   addClipSphere(clipSphere: IClipSphere): void {
@@ -161,26 +162,26 @@ export class Viewer {
     this.scene.add(this.clipSpheres[0].mesh);
   }
 
-  addClipPlane(clipPlane: IClipPlane): void {
-    const geometry = new THREE.PlaneGeometry( 5, 20, 32 );
-    const material = new THREE.MeshBasicMaterial({
-      color: '#ff00ff',
-      side: THREE.DoubleSide,
-      opacity: 0.25,
-      transparent: true, 
-    });
-    const plane = new THREE.Mesh( geometry, material );
-    this.clipPlanes.push({
-      iClipPlane: clipPlane,
-      geometry: geometry,
-      color: '#0000FF',
-      mesh: plane,
-      position: new THREE.Vector3(0, 0, 0),
-      rotation: new THREE.Quaternion(),
-      scale: new THREE.Vector3(1, 1, 1),
-    });
-    this.scene.add(plane);
-  }
+  // addClipPlane(clipPlane: IClipPlane): void {
+  //   const geometry = new THREE.PlaneGeometry( 5, 20, 32 );
+  //   const material = new THREE.MeshBasicMaterial({
+  //     color: '#ff00ff',
+  //     side: THREE.DoubleSide,
+  //     opacity: 0.25,
+  //     transparent: true, 
+  //   });
+  //   const plane = new THREE.Mesh( geometry, material );
+  //   this.clipPlanes.push({
+  //     iClipPlane: clipPlane,
+  //     geometry: geometry,
+  //     color: '#0000FF',
+  //     mesh: plane,
+  //     position: new THREE.Vector3(0, 0, 0),
+  //     rotation: new THREE.Quaternion(),
+  //     scale: new THREE.Vector3(1, 1, 1),
+  //   });
+  //   this.scene.add(plane);
+  // }
 
   updateClipMode() {
     const pcos = this.pointClouds;
@@ -270,65 +271,65 @@ export class Viewer {
     this.pointClouds[0].material.setClipSpheres([iClipSphere]);
   }
 
-  translateClipPlane = (translation: Vector3, axis: string) => {
-    const currentPos = this.clipPlanes[0].position;
-    if (axis === 'x') {
-      this.clipPlanes[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
-    } else if (axis === 'y') {
-      this.clipPlanes[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
-    } else if (axis === 'PZ') {
-      this.clipPlanes[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
-    }
+  // translateClipPlane = (translation: Vector3, axis: string) => {
+  //   const currentPos = this.clipPlanes[0].position;
+  //   if (axis === 'x') {
+  //     this.clipPlanes[0].position = new Vector3(translation.x, currentPos.y, currentPos.z);
+  //   } else if (axis === 'y') {
+  //     this.clipPlanes[0].position = new Vector3(currentPos.x, translation.y, currentPos.z);
+  //   } else if (axis === 'PZ') {
+  //     this.clipPlanes[0].position = new Vector3(currentPos.x, currentPos.y, translation.z);
+  //   }
     
-    this.clipPlanes[0].mesh.position.set(this.clipPlanes[0].position.x, this.clipPlanes[0].position.y, this.clipPlanes[0].position.z);
+  //   this.clipPlanes[0].mesh.position.set(this.clipPlanes[0].position.x, this.clipPlanes[0].position.y, this.clipPlanes[0].position.z);
 
-    let iClipPlane = this.clipPlanes[0].iClipPlane;
-    const m = new Matrix4();
-    m.compose(
-      this.clipPlanes[0].position,
-      this.clipPlanes[0].rotation,
-      this.clipPlanes[0].scale,
-    );
-    iClipPlane.matrix.getInverse(m);
-    console.log(iClipPlane.matrix);
+  //   let iClipPlane = this.clipPlanes[0].iClipPlane;
+  //   const m = new Matrix4();
+  //   m.compose(
+  //     this.clipPlanes[0].position,
+  //     this.clipPlanes[0].rotation,
+  //     this.clipPlanes[0].scale,
+  //   );
+  //   iClipPlane.matrix.getInverse(m);
+  //   console.log(iClipPlane.matrix);
 
-    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
-    const m2 = new Matrix4();
-    m2.compose(
-      this.clipPlanes[0].position,
-      this.clipPlanes[0].rotation,
-      this.clipPlanes[0].scale,
-    );
-    iClipPlane2.matrix.getInverse(m2);
+  //   let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+  //   const m2 = new Matrix4();
+  //   m2.compose(
+  //     this.clipPlanes[0].position,
+  //     this.clipPlanes[0].rotation,
+  //     this.clipPlanes[0].scale,
+  //   );
+  //   iClipPlane2.matrix.getInverse(m2);
 
-    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane]);
-  }
+  //   this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane]);
+  // }
 
-  rotateClipPlane = (rotationAngle: number) => {
-    this.clipPlanes[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
-    let newEuler = new THREE.Euler();
-    newEuler.setFromQuaternion(this.clipPlanes[0].rotation);
-    this.clipPlanes[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
-    let iClipPlane = this.clipPlanes[0].iClipPlane;
-    const m = new Matrix4;
-    m.compose(
-      this.clipPlanes[0].position,
-      this.clipPlanes[0].rotation,
-      this.clipPlanes[0].scale,
-    );
-    iClipPlane.matrix.getInverse(m);
+  // rotateClipPlane = (rotationAngle: number) => {
+  //   this.clipPlanes[0].rotation.setFromAxisAngle(new Vector3(1, 0, 0), rotationAngle);
+  //   let newEuler = new THREE.Euler();
+  //   newEuler.setFromQuaternion(this.clipPlanes[0].rotation);
+  //   this.clipPlanes[0].mesh.rotation.set(newEuler.x, newEuler.y, newEuler.z);
+  //   let iClipPlane = this.clipPlanes[0].iClipPlane;
+  //   const m = new Matrix4;
+  //   m.compose(
+  //     this.clipPlanes[0].position,
+  //     this.clipPlanes[0].rotation,
+  //     this.clipPlanes[0].scale,
+  //   );
+  //   iClipPlane.matrix.getInverse(m);
 
-    let iClipPlane2 = this.clipPlanes[1].iClipPlane;
-    const m2 = new Matrix4;
-    m2.compose(
-      this.clipPlanes[1].position,
-      this.clipPlanes[1].rotation,
-      this.clipPlanes[1].scale,
-    );
-    iClipPlane2.matrix.getInverse(m2);
+  //   let iClipPlane2 = this.clipPlanes[1].iClipPlane;
+  //   const m2 = new Matrix4;
+  //   m2.compose(
+  //     this.clipPlanes[1].position,
+  //     this.clipPlanes[1].rotation,
+  //     this.clipPlanes[1].scale,
+  //   );
+  //   iClipPlane2.matrix.getInverse(m2);
 
-    this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane2]);
-  }
+  //   this.pointClouds[0].material.setClipPlanes([iClipPlane, iClipPlane2]);
+  // }
 
   addAxes() {
     this.addAxis(new THREE.Vector3(-10, 0, 0), new THREE.Vector3(10, 0, 0), '#FF0000');

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "@pnext/three-loader",
+  "name": "@spelman7/three-loader",
   "private": false,
   "version": "0.1.1",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
-    "Hugo Campos <hugo.campos@pix4d.com>"
+    "Hugo Campos <hugo.campos@pix4d.com>",
+    "Elliott Spelman <elliott@ubiquity6.com>"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pnext/three-loader.git"
+    "url": "git+https://github.com/spelman7/three-loader.git"
   },
   "bugs": {
-    "url": "https://github.com/pnext/three-loader/issues"
+    "url": "https://github.com/spelman7/three-loader/issues"
   },
   "license": "MIT",
   "main": "build/potree.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.4",
+  "version": "0.1.7",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spelman7/three-loader",
   "private": false,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -1,4 +1,4 @@
-import { Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry, PlaneGeometry } from 'three';
+import { Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry } from 'three';
 
 export enum ClipMode {
   DISABLED = 0,
@@ -36,16 +36,16 @@ export type ClipSphere = {
   scale: Vector3,
 }
 
-export interface IClipPlane {
-  matrix: Matrix4;
-}
+// export interface IClipPlane {
+//   matrix: Matrix4;
+// }
 
-export type ClipPlane = {
-  iClipPlane: IClipPlane,
-  geometry: PlaneGeometry,
-  color: string,
-  mesh: Mesh,
-  position: Vector3,
-  rotation: Quaternion,
-  scale: Vector3,
-}
+// export type ClipPlane = {
+//   iClipPlane: IClipPlane,
+//   geometry: PlaneGeometry,
+//   color: string,
+//   mesh: Mesh,
+//   position: Vector3,
+//   rotation: Quaternion,
+//   scale: Vector3,
+// }

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -1,17 +1,15 @@
-import { Box3, Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry } from 'three';
+import { Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry, PlaneGeometry } from 'three';
 
 export enum ClipMode {
   DISABLED = 0,
   CLIP_OUTSIDE = 1,
-  HIGHLIGHT_INSIDE = 2,
-  CLIP_OUTSIDE_TEST = 3,
+  CLIP_INSIDE = 2,
+  HIGHLIGHT_INSIDE = 3,
+  CLIP_OUTSIDE_PICK = 4,
 }
 
 export interface IClipBox {
-  box: Box3;
-  inverse: Matrix4;
   matrix: Matrix4;
-  position: Vector3;
 }
 
 export type ClipBox = {
@@ -25,15 +23,26 @@ export type ClipBox = {
 }
 
 export interface IClipSphere {
-  radius: number;
-  inverse: Matrix4;
   matrix: Matrix4;
-  position: Vector3;
 }
 
 export type ClipSphere = {
   iClipSphere: IClipSphere,
   geometry: SphereGeometry,
+  color: string,
+  mesh: Mesh,
+  position: Vector3,
+  rotation: Quaternion,
+  scale: Vector3,
+}
+
+export interface IClipPlane {
+  matrix: Matrix4;
+}
+
+export type ClipPlane = {
+  iClipPlane: IClipPlane,
+  geometry: PlaneGeometry,
   color: string,
   mesh: Mesh,
   position: Vector3,

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -1,4 +1,4 @@
-import { Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry } from 'three';
+import { BoxGeometry, CylinderGeometry, Matrix4, Mesh, PlaneGeometry, Quaternion, SphereGeometry, Vector3 } from 'three';
 
 export enum ClipMode {
   DISABLED = 0,
@@ -20,7 +20,7 @@ export type ClipBox = {
   position: Vector3,
   rotation: Quaternion,
   scale: Vector3,
-}
+};
 
 export interface IClipSphere {
   matrix: Matrix4;
@@ -34,18 +34,32 @@ export type ClipSphere = {
   position: Vector3,
   rotation: Quaternion,
   scale: Vector3,
+};
+
+export interface IClipPlane {
+  matrix: Matrix4;
 }
 
-// export interface IClipPlane {
-//   matrix: Matrix4;
-// }
+export type ClipPlane = {
+  iClipPlane: IClipPlane,
+  geometry: PlaneGeometry,
+  color: string,
+  mesh: Mesh,
+  position: Vector3,
+  rotation: Quaternion,
+  scale: Vector3,
+};
 
-// export type ClipPlane = {
-//   iClipPlane: IClipPlane,
-//   geometry: PlaneGeometry,
-//   color: string,
-//   mesh: Mesh,
-//   position: Vector3,
-//   rotation: Quaternion,
-//   scale: Vector3,
-// }
+export interface IClipCylinder {
+  matrix: Matrix4;
+}
+
+export type ClipCylinder = {
+  iClipCylinder: IClipCylinder,
+  geometry: CylinderGeometry,
+  color: string,
+  mesh: Mesh,
+  position: Vector3,
+  rotation: Quaternion,
+  scale: Vector3,
+};

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -5,7 +5,8 @@ export enum ClipMode {
   CLIP_OUTSIDE = 1,
   CLIP_INSIDE = 2,
   HIGHLIGHT_INSIDE = 3,
-  CLIP_OUTSIDE_PICK = 4,
+  HIGHLIGHT_OUTSIDE = 4,
+  CLIP_OUTSIDE_PICK = 5,
 }
 
 export interface IClipBox {

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -1,9 +1,10 @@
-import { Box3, Matrix4, Vector3 } from 'three';
+import { Box3, Matrix4, Vector3, BoxGeometry, Mesh, Quaternion, SphereGeometry } from 'three';
 
 export enum ClipMode {
   DISABLED = 0,
   CLIP_OUTSIDE = 1,
   HIGHLIGHT_INSIDE = 2,
+  CLIP_OUTSIDE_TEST = 3,
 }
 
 export interface IClipBox {
@@ -11,4 +12,31 @@ export interface IClipBox {
   inverse: Matrix4;
   matrix: Matrix4;
   position: Vector3;
+}
+
+export type ClipBox = {
+  iClipBox: IClipBox,
+  geometry: BoxGeometry,
+  color: string,
+  mesh: Mesh,
+  position: Vector3,
+  rotation: Quaternion,
+  scale: Vector3,
+}
+
+export interface IClipSphere {
+  radius: number;
+  inverse: Matrix4;
+  matrix: Matrix4;
+  position: Vector3;
+}
+
+export type ClipSphere = {
+  iClipSphere: IClipSphere,
+  geometry: SphereGeometry,
+  color: string,
+  mesh: Mesh,
+  position: Vector3,
+  rotation: Quaternion,
+  scale: Vector3,
 }

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_RGB_GAMMA,
 } from '../constants';
 import { DEFAULT_CLASSIFICATION } from './classification';
-import { ClipMode, IClipBox, IClipSphere, IClipPlane } from './clipping';
+import { ClipMode, IClipBox, IClipSphere } from './clipping';
 import { PointColorType, PointOpacityType, PointShape, PointSizeType, TreeType } from './enums';
 import { SPECTRAL } from './gradients';
 import {
@@ -42,8 +42,8 @@ export interface IPointCloudMaterialUniforms {
   clipBoxes: IUniform<Float32Array>;
   clipSphereCount: IUniform<number>;
   clipSpheres: IUniform<Float32Array>;
-  clipPlaneCount: IUniform<number>;
-  clipPlanes: IUniform<Float32Array>;
+  // clipPlaneCount: IUniform<number>;
+  // clipPlanes: IUniform<Float32Array>;
   depthMap: IUniform<Texture | null>;
   diffuse: IUniform<[number, number, number]>;
   far: IUniform<number>;
@@ -139,8 +139,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
   clipBoxes: IClipBox[] = [];
   numClipSpheres: number = 0;
   clipSpheres: IClipSphere[] = [];
-  numClipPlanes: number = 0;
-  clipPlanes: IClipPlane[] = [];
+  // numClipPlanes: number = 0;
+  // clipPlanes: IClipPlane[] = [];
   readonly visibleNodesTexture: Texture;
 
   private _gradient = SPECTRAL;
@@ -158,8 +158,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
     clipBoxes: makeUniform('Matrix4fv', [] as any),
     clipSphereCount: makeUniform('f', 0),
     clipSpheres: makeUniform('Matrix4fv', [] as any),
-    clipPlaneCount: makeUniform('f', 0),
-    clipPlanes: makeUniform('Matrix4fv', [] as any),
+    // clipPlaneCount: makeUniform('f', 0),
+    // clipPlanes: makeUniform('Matrix4fv', [] as any),
     depthMap: makeUniform('t', null),
     diffuse: makeUniform('fv', [1, 1, 1] as [number, number, number]),
     far: makeUniform('f', 1.0),
@@ -354,9 +354,9 @@ export class PointCloudMaterial extends RawShaderMaterial {
       define('use_clip_sphere');
     }
 
-    if (this.numClipPlanes > 0) {
-      define('use_clip_plane');
-    }
+    // if (this.numClipPlanes > 0) {
+    //   define('use_clip_plane');
+    // }
 
     define('MAX_POINT_LIGHTS 0');
     define('MAX_DIR_LIGHTS 0');
@@ -432,38 +432,38 @@ export class PointCloudMaterial extends RawShaderMaterial {
     this.setUniform('clipSpheres', clipSpheresArray);
   }
   
-  setClipPlanes(clipPlanes: IClipPlane[]): void {
-		if (!clipPlanes) {
-			return;
-    }
+  // setClipPlanes(clipPlanes: IClipPlane[]): void {
+	// 	if (!clipPlanes) {
+	// 		return;
+  //   }
     
-    this.clipPlanes = clipPlanes;
+  //   this.clipPlanes = clipPlanes;
 
-		const doUpdate =
-      this.numClipPlanes !== clipPlanes.length && (clipPlanes.length === 0 || this.numClipPlanes === 0);
+	// 	const doUpdate =
+  //     this.numClipPlanes !== clipPlanes.length && (clipPlanes.length === 0 || this.numClipPlanes === 0);
 
-    this.numClipPlanes = clipPlanes.length;
-    this.setUniform('clipPlaneCount', this.numClipPlanes);
+  //   this.numClipPlanes = clipPlanes.length;
+  //   this.setUniform('clipPlaneCount', this.numClipPlanes);
 
-		if (doUpdate) {
-			this.updateShaderSource();
-    }
+	// 	if (doUpdate) {
+	// 		this.updateShaderSource();
+  //   }
 
-    const clipPlanesLength = this.numClipPlanes * 16;
-    let clipPlanesArray = new Float32Array(clipPlanesLength);
+  //   const clipPlanesLength = this.numClipPlanes * 16;
+  //   let clipPlanesArray = new Float32Array(clipPlanesLength);
 
-		for (let i = 0; i < this.numClipPlanes; i++) {
-      clipPlanesArray.set(clipPlanes[i].matrix.elements, 16 * i);
-    }
+	// 	for (let i = 0; i < this.numClipPlanes; i++) {
+  //     clipPlanesArray.set(clipPlanes[i].matrix.elements, 16 * i);
+  //   }
 
-    for (let i = 0; i < clipPlanesLength; i++) {
-      if (isNaN(clipPlanesArray[i])) {
-        clipPlanesArray[i] = Infinity;
-      }
-    }
+  //   for (let i = 0; i < clipPlanesLength; i++) {
+  //     if (isNaN(clipPlanesArray[i])) {
+  //       clipPlanesArray[i] = Infinity;
+  //     }
+  //   }
 
-    this.setUniform('clipPlanes', clipPlanesArray);
-	}
+  //   this.setUniform('clipPlanes', clipPlanesArray);
+	// }
 
   get gradient(): IGradient {
     return this._gradient;

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -131,6 +131,7 @@ const CLIP_MODE_DEFS = {
   [ClipMode.CLIP_OUTSIDE]: 'clip_outside',
   [ClipMode.CLIP_INSIDE]: 'clip_inside',
   [ClipMode.HIGHLIGHT_INSIDE]: 'clip_highlight_inside',
+  [ClipMode.HIGHLIGHT_OUTSIDE]: 'clip_highlight_outside',
   [ClipMode.CLIP_OUTSIDE_PICK]: 'clip_outside_pick',
 };
 

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -496,7 +496,7 @@ void main() {
 
 	#if defined use_clip_box
 		bool insideAny = false;
-		for (int i = 0; i < MAX_CLIP_BOXES; i++) {
+		for (int i = 0; i < max_clip_boxes; i++) {
 			if (i == int(clipBoxCount)) {
 				break;
 			}

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -1,9 +1,9 @@
 precision highp float;
 precision highp int;
 
-#define max_clip_boxes 30
-#define max_clip_spheres 30
-#define max_clip_planes 100
+#define max_clip_boxes 20
+#define max_clip_spheres 20
+// #define max_clip_planes 100
 
 attribute vec3 position;
 attribute vec3 color;
@@ -38,9 +38,9 @@ uniform float far;
 	uniform mat4 clipSpheres[max_clip_spheres];
 #endif
 
-#if defined use_clip_plane
-	uniform mat4 clipPlanes[max_clip_planes];
-#endif
+// #if defined use_clip_plane
+// 	uniform mat4 clipPlanes[max_clip_planes];
+// #endif
 
 uniform float heightMin;
 uniform float heightMax;
@@ -53,7 +53,7 @@ uniform vec3 uColor;
 uniform float opacity;
 uniform float clipBoxCount;
 uniform float clipSphereCount;
-uniform float clipPlaneCount;
+// uniform float clipPlaneCount;
 uniform float level;
 uniform float vnStart;
 uniform bool isLeafNode;
@@ -398,8 +398,6 @@ void doClipping() {
 			inside = inside && -0.5 <= clipPosition.z && clipPosition.z <= 0.5;
 			insideAny = insideAny || inside;
 		}
-
-		
 	#endif
 
 	#if defined use_clip_sphere
@@ -415,21 +413,18 @@ void doClipping() {
 		}
 	#endif
 
-	#if defined use_clip_plane
-		bool insideAll = true;
-		for (int i = 0; i < max_clip_planes; i++) {
-			if (i == int(clipPlaneCount)) {
-				break;
-			}
-
-			vec4 planeLocal = clipPlanes[i] * modelMatrix * vec4(position, 1.0);
-
-			bool insidePlane = planeLocal.z >= 0.0;
-			
-			insideAll = insideAll && insidePlane;
-		}
-		insideAny = insideAll || insideAny;
-	#endif
+	// #if defined use_clip_plane
+		// bool insideAll = true;
+		// for (int i = 0; i < max_clip_planes; i++) {
+			// if (i == int(clipPlaneCount)) {
+				// break;
+			// }
+			// vec4 planeLocal = clipPlanes[i] * modelMatrix * vec4(position, 1.0);
+			// bool insidePlane = planeLocal.z >= 0.0;
+			// insideAll = insideAll && insidePlane;
+		// }
+		// insideAny = insideAll || insideAny;
+	// #endif
 
 	if (!insideAny) {
 		#if defined clip_outside

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -1,7 +1,8 @@
 precision highp float;
 precision highp int;
 
-#define max_clip_boxes 30
+#define max_clip_boxes 10
+#define max_clip_spheres 10
 
 attribute vec3 position;
 attribute vec3 color;
@@ -32,6 +33,10 @@ uniform float far;
 	uniform mat4 clipBoxes[max_clip_boxes];
 #endif
 
+#if defined use_clip_sphere
+	uniform mat4 clipSpheres[max_clip_spheres];
+#endif
+
 uniform float heightMin;
 uniform float heightMax;
 uniform float size; // pixel size factor
@@ -42,6 +47,7 @@ uniform vec3 bbSize;
 uniform vec3 uColor;
 uniform float opacity;
 uniform float clipBoxCount;
+uniform float clipSphereCount;
 uniform float level;
 uniform float vnStart;
 uniform bool isLeafNode;
@@ -370,6 +376,60 @@ vec3 getCompositeColor() {
 	return c;
 }
 
+void doClipping() {
+	#if defined use_clip_box
+		bool insideAny = false;
+		for (int i = 0; i < max_clip_boxes; i++) {
+			if (i == int(clipBoxCount)) {
+				break;
+			}
+		
+			vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
+			bool inside = -0.5 <= clipPosition.x && clipPosition.x <= 0.5;
+			inside = inside && -0.5 <= clipPosition.y && clipPosition.y <= 0.5;
+			inside = inside && -0.5 <= clipPosition.z && clipPosition.z <= 0.5;
+			insideAny = insideAny || inside;
+		}
+
+		if (!insideAny) {
+			#if defined clip_outside
+				// gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
+				// vColor.b += 0.5;
+			#elif defined clip_highlight_inside && !defined(color_type_depth)
+				// float c = (vColor.r + vColor.g + vColor.b) / 6.0;
+			#elif defined clip_outside_test
+				gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
+			#endif
+		} else {
+			#if defined clip_highlight_inside
+				vColor.r += 0.5;
+			#elif defined clip_outside
+				vColor.g += 0.5;
+			#endif
+		}
+	#endif
+
+	#if defined use_clip_sphere
+		for (int i = 0; i < max_clip_spheres; i++) {
+			if (i == int(clipSphereCount)) {
+				break;
+			}
+			vec4 sphereLocal = clipSpheres[i] * modelMatrix * vec4(position, 1.0);
+			float distance = length(sphereLocal.xyz);
+
+			if(distance < 1.0){
+				#if defined clip_highlight_inside
+					vColor.r += 0.5; 
+				#endif
+			} else {
+				#if defined clip_outside_test
+					gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
+				#endif
+			}
+		}
+	#endif
+}
+
 void main() {
 	vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
 
@@ -494,30 +554,7 @@ void main() {
 	// CLIPPING
 	// ---------------------
 
-	#if defined use_clip_box
-		bool insideAny = false;
-		for (int i = 0; i < max_clip_boxes; i++) {
-			if (i == int(clipBoxCount)) {
-				break;
-			}
-		
-			vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
-			bool inside = -0.5 <= clipPosition.x && clipPosition.x <= 0.5;
-			inside = inside && -0.5 <= clipPosition.y && clipPosition.y <= 0.5;
-			inside = inside && -0.5 <= clipPosition.z && clipPosition.z <= 0.5;
-			insideAny = insideAny || inside;
-		}
+	doClipping();
 
-		if (!insideAny) {
-			#if defined clip_outside
-				gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
-			#elif defined clip_highlight_inside && !defined(color_type_depth)
-				float c = (vColor.r + vColor.g + vColor.b) / 6.0;
-			#endif
-		} else {
-			#if defined clip_highlight_inside
-				vColor.r += 0.5;
-			#endif
-		}
-	#endif
+	
 }

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -448,14 +448,18 @@ void doClipping() {
 	if (!insideAny) {
 		#if defined clip_outside
 			gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
-		#elif defined clip_highlight_inside && !defined(color_type_depth)
-			// float c = (vColor.r + vColor.g + vColor.b) / 6.0;
+		#elif defined clip_highlight_inside
+			vColor.g += 0.5;
+		#elif defined clip_highlight_outside
+			vColor.r += 0.5;
 		#endif
 	} else {
-		#if defined clip_highlight_inside
-			vColor.r += 0.5;
-		#elif defined clip_inside
+		#if defined clip_inside
 			gl_Position = vec4(1000.0, 1000.0, 1000.0, 1.0);
+		#elif defined clip_highlight_inside
+			vColor.r += 0.5;
+		#elif defined clip_highlight_outside
+			vColor.g += 0.5;
 		#endif
 	}
 }

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -403,8 +403,6 @@ void doClipping() {
 		} else {
 			#if defined clip_highlight_inside
 				vColor.r += 0.5;
-			#elif defined clip_outside
-				vColor.g += 0.5;
 			#endif
 		}
 	#endif

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -590,7 +590,7 @@ export class PointCloudOctree extends PointCloudTree {
     } else {
       pickMaterial.clipMode = material.clipMode;
       pickMaterial.setClipBoxes(
-        material.clipMode === ClipMode.CLIP_OUTSIDE ? material.clipBoxes : [],
+        material.clipMode === ClipMode.CLIP_OUTSIDE_PICK ? material.clipBoxes : [],
       );
     }
   }

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -275,7 +275,7 @@ export class Potree implements IPotree {
   private shouldClip(pointCloud: PointCloudOctree, boundingBox: Box3): boolean {
     const material = pointCloud.material;
 
-    if (material.numClipBoxes === 0 || material.clipMode !== ClipMode.CLIP_OUTSIDE) {
+    if (material.numClipBoxes === 0 || material.clipMode !== ClipMode.CLIP_OUTSIDE_PICK) {
       return false;
     }
 


### PR DESCRIPTION
Lots of clipping improvements - working boxes, spheres, planes (kind-of), and cylinders. 

I just continued previous work, but those actually all share the same geometry. The shapes are stored as a single position, rotation, scale (PRS) matrix which is passed to the vertex shader as a single floatArray uniform, which can then just move the position in the draw call of that vertex to be really far away or colored differently.

Every type of geometry, though, has a single PRS matrix, so you actually differentiate between different types of geometry with an SDF. The whole thing works with signed distance functions! Mine are really, really rudimentary, but I think you could implement lots of different types of geometry. [All the shapes listed here should be possible](https://iquilezles.org/www/articles/distfunctions/distfunctions.htm).

It makes it fun to think about how you could 'paint' on a point cloud, or to a point cloud, by changing the color associated with different clipping volumes. I think that'd be totally possible, and not a feature I've seen before in different point cloud viewer software. 

I still have some work to do on finishing up the PR, but wanted to get your feedback and a second set of eyes on anything that might be wrong.

Best,

Elliott