### PR TITLE
Fix clipping of nodes when CLIP_OUTSIDE is set

### DIFF
--- a/src/potree.ts
+++ b/src/potree.ts
@@ -291,11 +291,11 @@ export class Potree implements IPotree {
         new Vector3(0.5, 0.5, 0.5),
       ).applyMatrix4(clipMatrixWorld);
       if (box2.intersectsBox(clipBoxWorld)) {
-        return true;
+        return false;
       }
     }
 
-    return false;
+    return true;
   }
 
   private updateVisibilityStructures = (() => {


### PR DESCRIPTION
I was trying to use the CLIP_OUTSIDE mode but only got very few points to show up. I tracked it down to the `shouldClip` method which seems to return the wrong value. From its call

```ts
if (
  node.level > maxLevel ||
  !frustums[pointCloudIndex].intersectsBox(node.boundingBox) ||
  this.shouldClip(pointCloud, node.boundingBox)
) {
  continue;
}
```
and the early check in the method
```ts
if (material.numClipBoxes === 0 || material.clipMode !== ClipMode.CLIP_OUTSIDE) {
  return false;
}
```
I see that it should return `true` only when a node should be invisible (clipped). However in the checks further down it would return `false` when the node does not intersect with any of the clip boxes.