### PR TITLE
Exported point-cloud-octree-node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './materials';
 export * from './point-attributes';
 export * from './point-cloud-octree-geometry-node';
 export * from './point-cloud-octree-geometry';
+export * from './point-cloud-octree-node';
 export * from './point-cloud-octree';
 export * from './point-cloud-tree';
 export * from './potree';


### PR DESCRIPTION
Hi!

In our project, we had to import the `PointCloudOctreeNode`.

However, as it's not exported in `src/index.ts` as the other types, the import is quite ugly:
`import {PointCloudOctreeNode} from "@pnext/three-loader/build/declarations/point-cloud-octree-node";`

Could we please export everything from `point-cloud-octree-node` in order to avoid that?

Thanks a lot!

Best,
Sebastian