### PR TITLE
Upgrade three.js to r110 and rename addAttribute function

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "size-plugin": "^2.0.0",
     "standard-version": "7.0.0",
     "style-loader": "^1.0.0",
-    "three": "0.108.0",
+    "three": "0.110.0",
     "three-orbit-controls": "^82.1.0",
     "ts-loader": "^6.2.0",
     "tslint": "^5.20.0",

--- a/src/loading/binary-loader.ts
+++ b/src/loading/binary-loader.ts
@@ -187,19 +187,19 @@ export class BinaryLoader {
       const buffer = buffers[property].buffer;
 
       if (this.isAttribute(property, PointAttributeName.POSITION_CARTESIAN)) {
-        geometry.addAttribute('position', new BufferAttribute(new Float32Array(buffer), 3));
+        geometry.setAttribute('position', new BufferAttribute(new Float32Array(buffer), 3));
       } else if (this.isAttribute(property, PointAttributeName.COLOR_PACKED)) {
-        geometry.addAttribute('color', new BufferAttribute(new Uint8Array(buffer), 3, true));
+        geometry.setAttribute('color', new BufferAttribute(new Uint8Array(buffer), 3, true));
       } else if (this.isAttribute(property, PointAttributeName.INTENSITY)) {
-        geometry.addAttribute('intensity', new BufferAttribute(new Float32Array(buffer), 1));
+        geometry.setAttribute('intensity', new BufferAttribute(new Float32Array(buffer), 1));
       } else if (this.isAttribute(property, PointAttributeName.CLASSIFICATION)) {
-        geometry.addAttribute('classification', new BufferAttribute(new Uint8Array(buffer), 1));
+        geometry.setAttribute('classification', new BufferAttribute(new Uint8Array(buffer), 1));
       } else if (this.isAttribute(property, PointAttributeName.NORMAL_SPHEREMAPPED)) {
-        geometry.addAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
+        geometry.setAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
       } else if (this.isAttribute(property, PointAttributeName.NORMAL_OCT16)) {
-        geometry.addAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
+        geometry.setAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
       } else if (this.isAttribute(property, PointAttributeName.NORMAL)) {
-        geometry.addAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
+        geometry.setAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
       }
     });
   }
@@ -207,13 +207,13 @@ export class BinaryLoader {
   private addIndices(geometry: BufferGeometry, indices: ArrayBuffer): void {
     const indicesAttribute = new Uint8BufferAttribute(indices, 4);
     indicesAttribute.normalized = true;
-    geometry.addAttribute('indices', indicesAttribute);
+    geometry.setAttribute('indices', indicesAttribute);
   }
 
   private addNormalAttribute(geometry: BufferGeometry, numPoints: number): void {
     if (!geometry.getAttribute('normal')) {
       const buffer = new Float32Array(numPoints * 3);
-      geometry.addAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
+      geometry.setAttribute('normal', new BufferAttribute(new Float32Array(buffer), 3));
     }
   }
 

--- a/src/utils/box3-helper.ts
+++ b/src/utils/box3-helper.ts
@@ -35,7 +35,7 @@ export class Box3Helper extends LineSegments {
 
     const geometry = new BufferGeometry();
     geometry.setIndex(new BufferAttribute(indices, 1));
-    geometry.addAttribute('position', new BufferAttribute(positions, 3));
+    geometry.setAttribute('position', new BufferAttribute(positions, 3));
 
     const material = new LineBasicMaterial({ color: color });
 

--- a/src/workers/binary-decoder-worker-internal.ts
+++ b/src/workers/binary-decoder-worker-internal.ts
@@ -60,7 +60,7 @@ export function handleMessage(event: MessageEvent) {
   };
 
   for (const pointAttribute of ctx.pointAttributes.attributes) {
-    decodeAndAddAttribute(pointAttribute, ctx);
+    decodeAndsetAttribute(pointAttribute, ctx);
     ctx.currentOffset += pointAttribute.byteSize;
   }
 
@@ -99,7 +99,7 @@ function addEmptyClassificationBuffer(ctx: Ctx): void {
   };
 }
 
-function decodeAndAddAttribute(attribute: IPointAttribute, ctx: Ctx): void {
+function decodeAndsetAttribute(attribute: IPointAttribute, ctx: Ctx): void {
   const decodedAttribute = decodePointAttribute(attribute, ctx);
   if (decodedAttribute === undefined) {
     return;

--- a/src/workers/binary-decoder-worker-internal.ts
+++ b/src/workers/binary-decoder-worker-internal.ts
@@ -60,7 +60,7 @@ export function handleMessage(event: MessageEvent) {
   };
 
   for (const pointAttribute of ctx.pointAttributes.attributes) {
-    decodeAndsetAttribute(pointAttribute, ctx);
+    decodeAndAddAttribute(pointAttribute, ctx);
     ctx.currentOffset += pointAttribute.byteSize;
   }
 
@@ -99,7 +99,7 @@ function addEmptyClassificationBuffer(ctx: Ctx): void {
   };
 }
 
-function decodeAndsetAttribute(attribute: IPointAttribute, ctx: Ctx): void {
+function decodeAndAddAttribute(attribute: IPointAttribute, ctx: Ctx): void {
   const decodedAttribute = decodePointAttribute(attribute, ctx);
   if (decodedAttribute === undefined) {
     return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6479,10 +6479,10 @@ three-orbit-controls@^82.1.0:
   resolved "https://registry.yarnpkg.com/three-orbit-controls/-/three-orbit-controls-82.1.0.tgz#11a7f33d0a20ecec98f098b37780f6537374fab4"
   integrity sha1-EafzPQog7OyY8Jizd4D2U3N0+rQ=
 
-three@0.108.0:
-  version "0.108.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.108.0.tgz#53d26597c7932f214bb43f4655e566d2058143b5"
-  integrity sha512-d1ysIXwi8qTlbmMwrTxi5pYiiYIflEr0e48krP0LAY8ndS8c6fkLHn6NvRT+o76/Fs9PBLxFViuI62iGVWwwlg==
+three@0.110.0:
+  version "0.110.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.110.0.tgz#8719591de1336269113ee79f4268ba247b2324f8"
+  integrity sha512-wlurH8XBO9Sd5VIw8nBa+taLR20kqaI4e9FiuMh6tqK8eOS2q2R+ZoUyufbyDTVTHhs8GiTbv0r2CMLkwerFJg==
 
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"


### PR DESCRIPTION
Currently getting `THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().`  warning on a fresh install. Per three's release notes they've renamed the function to `setAttribute` so I updated the calls