### PR TITLE
Set the expected clear color when calling renderer.clear

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import {Color} from "three";
+
 export const DEFAULT_RGB_BRIGHTNESS = 0;
 export const DEFAULT_RGB_CONTRAST = 0;
 export const DEFAULT_RGB_GAMMA = 1;
@@ -9,3 +11,4 @@ export const DEFAULT_POINT_BUDGET = 1_000_000;
 export const MAX_LOADS_TO_GPU = 2;
 export const MAX_NUM_NODES_LOADING = 4;
 export const PERSPECTIVE_CAMERA = 'PerspectiveCamera';
+export const COLOR_BLACK = new Color(0, 0, 0);

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -3,6 +3,7 @@ import {
   BufferAttribute,
   BufferGeometry,
   Camera,
+  Color,
   Geometry,
   LinearFilter,
   Material,
@@ -451,7 +452,14 @@ export class PointCloudOctree extends PointCloudTree {
     renderer.state.setBlending(NoBlending);
 
     renderer.setRenderTarget(pickState.renderTarget);
+
+    // Save the current clear color and clear the renderer with black color and alpha 0.
+    const oldClearColor = renderer.getClearColor();
+    const oldClearAlpha = renderer.getClearAlpha();
+    renderer.setClearColor(new Color(0, 0, 0), 0);
     renderer.clear(true, true, true);
+    renderer.setClearColor(oldClearColor, oldClearAlpha);
+
     renderer.render(pickState.scene, camera);
 
     // Read the pixel from the pick render target.

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -3,7 +3,6 @@ import {
   BufferAttribute,
   BufferGeometry,
   Camera,
-  Color,
   Geometry,
   LinearFilter,
   Material,
@@ -22,7 +21,7 @@ import {
   WebGLRenderer,
   WebGLRenderTarget,
 } from 'three';
-import { DEFAULT_MIN_NODE_PIXEL_SIZE, DEFAULT_PICK_WINDOW_SIZE } from './constants';
+import { DEFAULT_MIN_NODE_PIXEL_SIZE, DEFAULT_PICK_WINDOW_SIZE, COLOR_BLACK } from './constants';
 import { ClipMode, PointCloudMaterial, PointColorType, PointSizeType } from './materials';
 import { PointCloudOctreeGeometry } from './point-cloud-octree-geometry';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
@@ -456,7 +455,7 @@ export class PointCloudOctree extends PointCloudTree {
     // Save the current clear color and clear the renderer with black color and alpha 0.
     const oldClearColor = renderer.getClearColor();
     const oldClearAlpha = renderer.getClearAlpha();
-    renderer.setClearColor(new Color(0, 0, 0), 0);
+    renderer.setClearColor(COLOR_BLACK, 0);
     renderer.clear(true, true, true);
     renderer.setClearColor(oldClearColor, oldClearAlpha);
 


### PR DESCRIPTION
- When we clear the renderer and renderer's `clearAlpha` is different from what we expect the point picking logic can fail.

```
        if (pcIndex > 0 && distance < min) {
          hit = {
            pIndex: pIndex,
            pcIndex: pcIndex - 1,
          };
          min = distance;
        }
```
In case the clear alpha for the clear colour is anything other than zero, it will consider it as a hit, and will fail when calling the `getPickPoint` method.

The changes introduced in this PR will fix that by changing the current clear colour to the expected clear colour and after clearing will reset the clear colour to the original clear colour.