### PR TITLE
Multi cloud picking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './point-attributes';
 export * from './point-cloud-octree-geometry-node';
 export * from './point-cloud-octree-geometry';
 export * from './point-cloud-octree-node';
+export * from './point-cloud-octree-picker';
 export * from './point-cloud-octree';
 export * from './point-cloud-tree';
 export * from './potree';

--- a/src/materials/blur-material.ts
+++ b/src/materials/blur-material.ts
@@ -5,8 +5,6 @@ import { IUniform } from './types';
 
 export interface IBlurMaterialUniforms {
   [name: string]: IUniform<any>;
-  near: IUniform<number>;
-  far: IUniform<number>;
   screenWidth: IUniform<number>;
   screenHeight: IUniform<number>;
   map: IUniform<Texture | null>;
@@ -16,8 +14,6 @@ export class BlurMaterial extends ShaderMaterial {
   vertexShader = require('./shaders/blur.vert');
   fragmentShader = require('./shaders/blur.frag');
   uniforms: IBlurMaterialUniforms = {
-    near: { type: 'f', value: 0 },
-    far: { type: 'f', value: 0 },
     screenWidth: { type: 'f', value: 0 },
     screenHeight: { type: 'f', value: 0 },
     map: { type: 't', value: null },

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -1,12 +1,20 @@
 import {
   AdditiveBlending,
+  BufferGeometry,
+  Camera,
   Color,
+  Geometry,
   LessEqualDepth,
+  Material,
   NearestFilter,
   NoBlending,
+  PerspectiveCamera,
   RawShaderMaterial,
+  Scene,
   Texture,
+  Vector3,
   VertexColors,
+  WebGLRenderer,
 } from 'three';
 import {
   DEFAULT_MAX_POINT_SIZE,
@@ -14,7 +22,11 @@ import {
   DEFAULT_RGB_BRIGHTNESS,
   DEFAULT_RGB_CONTRAST,
   DEFAULT_RGB_GAMMA,
+  PERSPECTIVE_CAMERA,
 } from '../constants';
+import { PointCloudOctree } from '../point-cloud-octree';
+import { PointCloudOctreeNode } from '../point-cloud-octree-node';
+import { byLevelAndIndex } from '../utils/utils';
 import { DEFAULT_CLASSIFICATION } from './classification';
 import { ClipMode, IClipBox } from './clipping';
 import { PointColorType, PointOpacityType, PointShape, PointSizeType, TreeType } from './enums';
@@ -125,11 +137,14 @@ const CLIP_MODE_DEFS = {
 };
 
 export class PointCloudMaterial extends RawShaderMaterial {
+  private static helperVec3 = new Vector3();
+
   lights = false;
   fog = false;
   numClipBoxes: number = 0;
   clipBoxes: IClipBox[] = [];
   visibleNodesTexture: Texture | undefined;
+  private visibleNodeTextureOffsets = new Map<string, number>();
 
   private _gradient = SPECTRAL;
   private gradientTexture: Texture | undefined = generateGradientTexture(this._gradient);
@@ -196,6 +211,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
   @uniform('intensityRange') intensityRange!: [number, number];
   @uniform('maxSize') maxSize!: number;
   @uniform('minSize') minSize!: number;
+  @uniform('octreeSize') octreeSize!: number;
   @uniform('opacity', true) opacity!: number;
   @uniform('rgbBrightness', true) rgbBrightness!: number;
   @uniform('rgbContrast', true) rgbContrast!: number;
@@ -275,6 +291,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
       this.visibleNodesTexture = undefined;
     }
 
+    this.clearVisibleNodeTextureOffsets();
+
     if (this.classificationTexture) {
       this.classificationTexture.dispose();
       this.classificationTexture = undefined;
@@ -284,6 +302,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
       this.depthMap.dispose();
       this.depthMap = undefined;
     }
+  }
+
+  clearVisibleNodeTextureOffsets(): void {
+    this.visibleNodeTextureOffsets.clear();
   }
 
   updateShaderSource(): void {
@@ -471,6 +493,107 @@ export class PointCloudMaterial extends RawShaderMaterial {
     } else if (value !== uObj.value) {
       uObj.value = value;
     }
+  }
+
+  updateMaterial(
+    octree: PointCloudOctree,
+    visibleNodes: PointCloudOctreeNode[],
+    camera: Camera,
+    renderer: WebGLRenderer,
+  ): void {
+    const pixelRatio = renderer.getPixelRatio();
+
+    if (camera.type === PERSPECTIVE_CAMERA) {
+      this.fov = (camera as PerspectiveCamera).fov * (Math.PI / 180);
+    } else {
+      this.fov = Math.PI / 2; // will result in slope = 1 in the shader
+    }
+    this.screenWidth = renderer.domElement.clientWidth * pixelRatio;
+    this.screenHeight = renderer.domElement.clientHeight * pixelRatio;
+
+    const maxScale = Math.max(octree.scale.x, octree.scale.y, octree.scale.z);
+    this.spacing = octree.pcoGeometry.spacing * maxScale;
+    this.octreeSize = octree.pcoGeometry.boundingBox.getSize(PointCloudMaterial.helperVec3).x;
+
+    if (
+      this.pointSizeType === PointSizeType.ADAPTIVE ||
+      this.pointColorType === PointColorType.LOD
+    ) {
+      this.updateVisibilityTextureData(visibleNodes);
+    }
+  }
+
+  private updateVisibilityTextureData(nodes: PointCloudOctreeNode[]) {
+    nodes.sort(byLevelAndIndex);
+
+    const data = new Uint8Array(nodes.length * 4);
+    const offsetsToChild = new Array(nodes.length).fill(Infinity);
+
+    this.visibleNodeTextureOffsets.clear();
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+
+      this.visibleNodeTextureOffsets.set(node.name, i);
+
+      if (i > 0) {
+        const parentName = node.name.slice(0, -1);
+        const parentOffset = this.visibleNodeTextureOffsets.get(parentName)!;
+        const parentOffsetToChild = i - parentOffset;
+
+        offsetsToChild[parentOffset] = Math.min(offsetsToChild[parentOffset], parentOffsetToChild);
+
+        // tslint:disable:no-bitwise
+        const offset = parentOffset * 4;
+        data[offset] = data[offset] | (1 << node.index);
+        data[offset + 1] = offsetsToChild[parentOffset] >> 8;
+        data[offset + 2] = offsetsToChild[parentOffset] % 256;
+        // tslint:enable:no-bitwise
+      }
+
+      data[i * 4 + 3] = node.name.length;
+    }
+
+    const texture = this.visibleNodesTexture;
+    if (texture) {
+      texture.image.data.set(data);
+      texture.needsUpdate = true;
+    }
+  }
+
+  static makeOnBeforeRender(
+    octree: PointCloudOctree,
+    node: PointCloudOctreeNode,
+    pcIndex?: number,
+  ) {
+    return (
+      _renderer: WebGLRenderer,
+      _scene: Scene,
+      _camera: Camera,
+      _geometry: Geometry | BufferGeometry,
+      material: Material,
+    ) => {
+      const pointCloudMaterial = material as PointCloudMaterial;
+      const materialUniforms = pointCloudMaterial.uniforms;
+
+      materialUniforms.level.value = node.level;
+      materialUniforms.isLeafNode.value = node.isLeafNode;
+
+      const vnStart = pointCloudMaterial.visibleNodeTextureOffsets.get(node.name);
+      if (vnStart !== undefined) {
+        materialUniforms.vnStart.value = vnStart;
+      }
+
+      materialUniforms.pcIndex.value =
+        pcIndex !== undefined ? pcIndex : octree.visibleNodes.indexOf(node);
+
+      // Note: when changing uniforms in onBeforeRender, the flag uniformsNeedUpdate has to be
+      // set to true to instruct ThreeJS to upload them. See also
+      // https://github.com/mrdoob/three.js/issues/9870#issuecomment-368750182.
+
+      // Remove the cast to any after updating to Three.JS >= r113
+      (material as any) /*ShaderMaterial*/.uniformsNeedUpdate = true;
+    };
   }
 }
 

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -42,7 +42,6 @@ export interface IPointCloudMaterialUniforms {
   clipBoxes: IUniform<Float32Array>;
   depthMap: IUniform<Texture | null>;
   diffuse: IUniform<[number, number, number]>;
-  far: IUniform<number>;
   fov: IUniform<number>;
   gradient: IUniform<Texture>;
   heightMax: IUniform<number>;
@@ -54,7 +53,6 @@ export interface IPointCloudMaterialUniforms {
   level: IUniform<number>;
   maxSize: IUniform<number>;
   minSize: IUniform<number>;
-  near: IUniform<number>;
   octreeSize: IUniform<number>;
   opacity: IUniform<number>;
   pcIndex: IUniform<number>;
@@ -150,7 +148,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
     clipBoxes: makeUniform('Matrix4fv', [] as any),
     depthMap: makeUniform('t', null),
     diffuse: makeUniform('fv', [1, 1, 1] as [number, number, number]),
-    far: makeUniform('f', 1.0),
     fov: makeUniform('f', 1.0),
     gradient: makeUniform('t', this.gradientTexture || new Texture()),
     heightMax: makeUniform('f', 1.0),
@@ -163,7 +160,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
     level: makeUniform('f', 0.0),
     maxSize: makeUniform('f', DEFAULT_MAX_POINT_SIZE),
     minSize: makeUniform('f', DEFAULT_MIN_POINT_SIZE),
-    near: makeUniform('f', 0.1),
     octreeSize: makeUniform('f', 0),
     opacity: makeUniform('f', 1.0),
     pcIndex: makeUniform('f', 0),
@@ -191,7 +187,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
   @uniform('bbSize') bbSize!: [number, number, number];
   @uniform('depthMap') depthMap!: Texture | undefined;
-  @uniform('far') far!: number;
   @uniform('fov') fov!: number;
   @uniform('heightMax') heightMax!: number;
   @uniform('heightMin') heightMin!: number;
@@ -201,7 +196,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
   @uniform('intensityRange') intensityRange!: [number, number];
   @uniform('maxSize') maxSize!: number;
   @uniform('minSize') minSize!: number;
-  @uniform('near') near!: number;
   @uniform('opacity', true) opacity!: number;
   @uniform('rgbBrightness', true) rgbBrightness!: number;
   @uniform('rgbContrast', true) rgbContrast!: number;

--- a/src/materials/shaders/blur.frag
+++ b/src/materials/shaders/blur.frag
@@ -5,8 +5,6 @@ uniform mat4 projectionMatrix;
 
 uniform float screenWidth;
 uniform float screenHeight;
-uniform float near;
-uniform float far;
 
 uniform sampler2D map;
 

--- a/src/materials/shaders/pointcloud.frag
+++ b/src/materials/shaders/pointcloud.frag
@@ -15,8 +15,6 @@ uniform float blendHardness;
 uniform float blendDepthSupplement;
 uniform float fov;
 uniform float spacing;
-uniform float near;
-uniform float far;
 uniform float pcIndex;
 uniform float screenWidth;
 uniform float screenHeight;

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -25,8 +25,6 @@ uniform float screenWidth;
 uniform float screenHeight;
 uniform float fov;
 uniform float spacing;
-uniform float near;
-uniform float far;
 
 #if defined use_clip_box
 	uniform mat4 clipBoxes[max_clip_boxes];

--- a/src/point-cloud-octree-picker.ts
+++ b/src/point-cloud-octree-picker.ts
@@ -1,0 +1,410 @@
+import {
+  BufferAttribute,
+  Camera,
+  LinearFilter,
+  NearestFilter,
+  NoBlending,
+  Points,
+  Ray,
+  RGBAFormat,
+  Scene,
+  Sphere,
+  Vector3,
+  Vector4,
+  WebGLRenderer,
+  WebGLRenderTarget,
+} from 'three';
+import { COLOR_BLACK, DEFAULT_PICK_WINDOW_SIZE } from './constants';
+import { ClipMode, PointCloudMaterial, PointColorType } from './materials';
+import { PointCloudOctree } from './point-cloud-octree';
+import { PointCloudOctreeNode } from './point-cloud-octree-node';
+import { PickPoint, PointCloudHit } from './types';
+import { clamp } from './utils/math';
+
+export interface PickParams {
+  pickWindowSize: number;
+  pickOutsideClipRegion: boolean;
+  /**
+   * If provided, the picking will use this pixel position instead of the `Ray` passed to the `pick`
+   * method.
+   */
+  pixelPosition: Vector3;
+  /**
+   * Function which gets called after a picking material has been created and setup and before the
+   * point cloud is rendered into the picking render target. This gives applications a chance to
+   * customize the renderTarget and the material.
+   *
+   * @param material
+   *    The pick material.
+   * @param renterTarget
+   *    The render target used for picking.
+   */
+  onBeforePickRender: (material: PointCloudMaterial, renterTarget: WebGLRenderTarget) => void;
+}
+
+interface IPickState {
+  renderTarget: WebGLRenderTarget;
+  material: PointCloudMaterial;
+  scene: Scene;
+}
+
+export class PointCloudOctreePicker {
+  private static readonly helperVec3 = new Vector3();
+  private static readonly helperSphere = new Sphere();
+
+  private pickState: IPickState | undefined;
+
+  dispose() {
+    if (this.pickState) {
+      this.pickState.material.dispose();
+      this.pickState.renderTarget.dispose();
+    }
+  }
+
+  pick(
+    renderer: WebGLRenderer,
+    camera: Camera,
+    ray: Ray,
+    octrees: PointCloudOctree[],
+    params: Partial<PickParams> = {},
+  ): PickPoint | null {
+    if (octrees.length === 0) {
+      return null;
+    }
+
+    const pickState = this.pickState
+      ? this.pickState
+      : (this.pickState = PointCloudOctreePicker.getPickState());
+
+    const pickMaterial = pickState.material;
+
+    const pixelRatio = renderer.getPixelRatio();
+    const width = Math.ceil(renderer.domElement.clientWidth * pixelRatio);
+    const height = Math.ceil(renderer.domElement.clientHeight * pixelRatio);
+    PointCloudOctreePicker.updatePickRenderTarget(this.pickState, width, height);
+
+    const pixelPosition = PointCloudOctreePicker.helperVec3; // Use helper vector to prevent extra allocations.
+
+    if (params.pixelPosition) {
+      pixelPosition.copy(params.pixelPosition);
+    } else {
+      pixelPosition.addVectors(camera.position, ray.direction).project(camera);
+      pixelPosition.x = (pixelPosition.x + 1) * width * 0.5;
+      pixelPosition.y = (pixelPosition.y + 1) * height * 0.5;
+    }
+
+    const pickWndSize = Math.floor(
+      (params.pickWindowSize || DEFAULT_PICK_WINDOW_SIZE) * pixelRatio,
+    );
+    const halfPickWndSize = (pickWndSize - 1) / 2;
+    const x = Math.floor(clamp(pixelPosition.x - halfPickWndSize, 0, width));
+    const y = Math.floor(clamp(pixelPosition.y - halfPickWndSize, 0, height));
+
+    PointCloudOctreePicker.prepareRender(renderer, x, y, pickWndSize, pickMaterial, pickState);
+
+    const renderedNodes = PointCloudOctreePicker.render(
+      renderer,
+      camera,
+      pickMaterial,
+      octrees,
+      ray,
+      pickState,
+      params,
+    );
+
+    // Cleanup
+    pickMaterial.clearVisibleNodeTextureOffsets();
+
+    // Read back image and decode hit point
+    const pixels = PointCloudOctreePicker.readPixels(renderer, x, y, pickWndSize);
+    const hit = PointCloudOctreePicker.findHit(pixels, pickWndSize);
+    return PointCloudOctreePicker.getPickPoint(hit, renderedNodes);
+  }
+
+  private static prepareRender(
+    renderer: WebGLRenderer,
+    x: number,
+    y: number,
+    pickWndSize: number,
+    pickMaterial: PointCloudMaterial,
+    pickState: IPickState,
+  ) {
+    // Render the intersected nodes onto the pick render target, clipping to a small pick window.
+    renderer.setScissor(x, y, pickWndSize, pickWndSize);
+    renderer.setScissorTest(true);
+    renderer.state.buffers.depth.setTest(pickMaterial.depthTest);
+    renderer.state.buffers.depth.setMask(pickMaterial.depthWrite);
+    renderer.state.setBlending(NoBlending);
+
+    renderer.setRenderTarget(pickState.renderTarget);
+
+    // Save the current clear color and clear the renderer with black color and alpha 0.
+    const oldClearColor = renderer.getClearColor();
+    const oldClearAlpha = renderer.getClearAlpha();
+    renderer.setClearColor(COLOR_BLACK, 0);
+    renderer.clear(true, true, true);
+    renderer.setClearColor(oldClearColor, oldClearAlpha);
+  }
+
+  private static render(
+    renderer: WebGLRenderer,
+    camera: Camera,
+    pickMaterial: PointCloudMaterial,
+    octrees: PointCloudOctree[],
+    ray: Ray,
+    pickState: IPickState,
+    params: Partial<PickParams>,
+  ): PointCloudOctreeNode[] {
+    const renderedNodes: PointCloudOctreeNode[] = [];
+    for (const octree of octrees) {
+      // Get all the octree nodes which intersect the picking ray. We only need to render those.
+      const nodes = PointCloudOctreePicker.nodesOnRay(octree, ray);
+      if (!nodes.length) {
+        continue;
+      }
+
+      PointCloudOctreePicker.updatePickMaterial(pickMaterial, octree.material, params);
+      pickMaterial.updateMaterial(octree, nodes, camera, renderer);
+
+      if (params.onBeforePickRender) {
+        params.onBeforePickRender(pickMaterial, pickState.renderTarget);
+      }
+
+      // Create copies of the nodes so we can render them differently than in the normal point cloud.
+      pickState.scene.children = PointCloudOctreePicker.createTempNodes(
+        octree,
+        nodes,
+        pickMaterial,
+        renderedNodes.length,
+      );
+
+      renderer.render(pickState.scene, camera);
+
+      renderedNodes.push(...nodes);
+    }
+    return renderedNodes;
+  }
+
+  private static nodesOnRay(octree: PointCloudOctree, ray: Ray): PointCloudOctreeNode[] {
+    const nodesOnRay: PointCloudOctreeNode[] = [];
+
+    const rayClone = ray.clone();
+    for (const node of octree.visibleNodes) {
+      const sphere = PointCloudOctreePicker.helperSphere
+        .copy(node.boundingSphere)
+        .applyMatrix4(octree.matrixWorld);
+
+      if (rayClone.intersectsSphere(sphere)) {
+        nodesOnRay.push(node);
+      }
+    }
+
+    return nodesOnRay;
+  }
+
+  private static readPixels(
+    renderer: WebGLRenderer,
+    x: number,
+    y: number,
+    pickWndSize: number,
+  ): Uint8Array {
+    // Read the pixel from the pick render target.
+    const pixels = new Uint8Array(4 * pickWndSize * pickWndSize);
+    renderer.readRenderTargetPixels(
+      renderer.getRenderTarget()!,
+      x,
+      y,
+      pickWndSize,
+      pickWndSize,
+      pixels,
+    );
+    renderer.setScissorTest(false);
+    renderer.setRenderTarget(null!);
+    return pixels;
+  }
+
+  private static createTempNodes(
+    octree: PointCloudOctree,
+    nodes: PointCloudOctreeNode[],
+    pickMaterial: PointCloudMaterial,
+    nodeIndexOffset: number,
+  ): Points[] {
+    const tempNodes: Points[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      const sceneNode = node.sceneNode;
+      const tempNode = new Points(sceneNode.geometry, pickMaterial);
+      tempNode.matrix = sceneNode.matrix;
+      tempNode.matrixWorld = sceneNode.matrixWorld;
+      tempNode.matrixAutoUpdate = false;
+      tempNode.frustumCulled = false;
+      const nodeIndex = nodeIndexOffset + i + 1;
+      if (nodeIndex > 255) {
+        console.error('More than 255 nodes for pick are not supported.');
+      }
+      tempNode.onBeforeRender = PointCloudMaterial.makeOnBeforeRender(octree, node, nodeIndex);
+
+      tempNodes.push(tempNode);
+    }
+    return tempNodes;
+  }
+
+  private static updatePickMaterial(
+    pickMaterial: PointCloudMaterial,
+    nodeMaterial: PointCloudMaterial,
+    params: Partial<PickParams>,
+  ): void {
+    pickMaterial.pointSizeType = nodeMaterial.pointSizeType;
+    pickMaterial.shape = nodeMaterial.shape;
+    pickMaterial.size = nodeMaterial.size;
+    pickMaterial.minSize = nodeMaterial.minSize;
+    pickMaterial.maxSize = nodeMaterial.maxSize;
+    pickMaterial.classification = nodeMaterial.classification;
+    pickMaterial.useFilterByNormal = nodeMaterial.useFilterByNormal;
+    pickMaterial.filterByNormalThreshold = nodeMaterial.filterByNormalThreshold;
+
+    if (params.pickOutsideClipRegion) {
+      pickMaterial.clipMode = ClipMode.DISABLED;
+    } else {
+      pickMaterial.clipMode = nodeMaterial.clipMode;
+      pickMaterial.setClipBoxes(
+        nodeMaterial.clipMode === ClipMode.CLIP_OUTSIDE ? nodeMaterial.clipBoxes : [],
+      );
+    }
+  }
+
+  private static updatePickRenderTarget(
+    pickState: IPickState,
+    width: number,
+    height: number,
+  ): void {
+    if (pickState.renderTarget.width === width && pickState.renderTarget.height === height) {
+      return;
+    }
+
+    pickState.renderTarget.dispose();
+    pickState.renderTarget = PointCloudOctreePicker.makePickRenderTarget();
+    pickState.renderTarget.setSize(width, height);
+  }
+
+  private static makePickRenderTarget() {
+    return new WebGLRenderTarget(1, 1, {
+      minFilter: LinearFilter,
+      magFilter: NearestFilter,
+      format: RGBAFormat,
+    });
+  }
+
+  private static findHit(pixels: Uint8Array, pickWndSize: number): PointCloudHit | null {
+    const ibuffer = new Uint32Array(pixels.buffer);
+
+    // Find closest hit inside pixelWindow boundaries
+    let min = Number.MAX_VALUE;
+    let hit: PointCloudHit | null = null;
+    for (let u = 0; u < pickWndSize; u++) {
+      for (let v = 0; v < pickWndSize; v++) {
+        const offset = u + v * pickWndSize;
+        const distance =
+          Math.pow(u - (pickWndSize - 1) / 2, 2) + Math.pow(v - (pickWndSize - 1) / 2, 2);
+
+        const pcIndex = pixels[4 * offset + 3];
+        pixels[4 * offset + 3] = 0;
+        const pIndex = ibuffer[offset];
+
+        if (pcIndex > 0 && distance < min) {
+          hit = {
+            pIndex: pIndex,
+            pcIndex: pcIndex - 1,
+          };
+          min = distance;
+        }
+      }
+    }
+    return hit;
+  }
+
+  private static getPickPoint(
+    hit: PointCloudHit | null,
+    nodes: PointCloudOctreeNode[],
+  ): PickPoint | null {
+    if (!hit) {
+      return null;
+    }
+
+    const point: PickPoint = {};
+
+    const points = nodes[hit.pcIndex] && nodes[hit.pcIndex].sceneNode;
+    if (!points) {
+      return null;
+    }
+
+    const attributes: BufferAttribute[] = (points.geometry as any).attributes;
+
+    for (const property in attributes) {
+      if (!attributes.hasOwnProperty(property)) {
+        continue;
+      }
+
+      const values = attributes[property];
+
+      // tslint:disable-next-line:prefer-switch
+      if (property === 'position') {
+        PointCloudOctreePicker.addPositionToPickPoint(point, hit, values, points);
+      } else if (property === 'normal') {
+        PointCloudOctreePicker.addNormalToPickPoint(point, hit, values, points);
+      } else if (property === 'indices') {
+        // TODO
+      } else {
+        if (values.itemSize === 1) {
+          point[property] = values.array[hit.pIndex];
+        } else {
+          const value = [];
+          for (let j = 0; j < values.itemSize; j++) {
+            value.push(values.array[values.itemSize * hit.pIndex + j]);
+          }
+          point[property] = value;
+        }
+      }
+    }
+
+    return point;
+  }
+
+  private static addPositionToPickPoint(
+    point: PickPoint,
+    hit: PointCloudHit,
+    values: BufferAttribute,
+    points: Points,
+  ): void {
+    point.position = new Vector3()
+      .fromBufferAttribute(values, hit.pIndex)
+      .applyMatrix4(points.matrixWorld);
+  }
+
+  private static addNormalToPickPoint(
+    point: PickPoint,
+    hit: PointCloudHit,
+    values: BufferAttribute,
+    points: Points,
+  ): void {
+    const normal = new Vector3().fromBufferAttribute(values, hit.pIndex);
+    const normal4 = new Vector4(normal.x, normal.y, normal.z, 0).applyMatrix4(points.matrixWorld);
+    normal.set(normal4.x, normal4.y, normal4.z);
+
+    point.normal = normal;
+  }
+
+  private static getPickState() {
+    const scene = new Scene();
+    scene.autoUpdate = false;
+
+    const material = new PointCloudMaterial();
+    material.pointColorType = PointColorType.POINT_INDEX;
+
+    return {
+      renderTarget: PointCloudOctreePicker.makePickRenderTarget(),
+      material: material,
+      scene: scene,
+    };
+  }
+}

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -254,8 +254,6 @@ export class PointCloudOctree extends PointCloudTree {
     material.fov = camera.fov * (Math.PI / 180);
     material.screenWidth = renderer.domElement.clientWidth * pixelRatio;
     material.screenHeight = renderer.domElement.clientHeight * pixelRatio;
-    material.near = camera.near;
-    material.far = camera.far;
     material.spacing = this.pcoGeometry.spacing * maxScale;
     material.uniforms.octreeSize.value = this.pcoGeometry.boundingBox.getSize(helperVec3).x;
 

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -1,65 +1,13 @@
-import {
-  Box3,
-  BufferAttribute,
-  BufferGeometry,
-  Camera,
-  Geometry,
-  LinearFilter,
-  Material,
-  Matrix4,
-  NearestFilter,
-  NoBlending,
-  Object3D,
-  PerspectiveCamera,
-  Points,
-  Ray,
-  RGBAFormat,
-  Scene,
-  Sphere,
-  Vector3,
-  Vector4,
-  WebGLRenderer,
-  WebGLRenderTarget,
-} from 'three';
-import { COLOR_BLACK, DEFAULT_MIN_NODE_PIXEL_SIZE, DEFAULT_PICK_WINDOW_SIZE } from './constants';
-import { ClipMode, PointCloudMaterial, PointColorType, PointSizeType } from './materials';
+import { Box3, Camera, Object3D, Points, Ray, Sphere, Vector3, WebGLRenderer } from 'three';
+import { DEFAULT_MIN_NODE_PIXEL_SIZE } from './constants';
+import { PointCloudMaterial, PointSizeType } from './materials';
 import { PointCloudOctreeGeometry } from './point-cloud-octree-geometry';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
 import { PointCloudOctreeNode } from './point-cloud-octree-node';
+import { PickParams, PointCloudOctreePicker } from './point-cloud-octree-picker';
 import { PointCloudTree } from './point-cloud-tree';
-import { IPointCloudTreeNode, IPotree, PickPoint, PointCloudHit } from './types';
+import { IPointCloudTreeNode, IPotree, PickPoint } from './types';
 import { computeTransformedBoundingBox } from './utils/bounds';
-import { clamp } from './utils/math';
-import { byLevelAndIndex } from './utils/utils';
-
-export interface PickParams {
-  pickWindowSize: number;
-  pickOutsideClipRegion: boolean;
-  /**
-   * If provided, the picking will use this pixel position instead of the `Ray` passed to the `pick`
-   * method.
-   */
-  pixelPosition: Vector3;
-  /**
-   * Function which gets called after a picking material has been created and setup and before the
-   * point cloud is rendered into the picking render target. This gives applications a chance to
-   * customize the renderTarget and the material.
-   *
-   * @param material
-   *    The pick material.
-   * @param renterTarget
-   *    The render target used for picking.
-   */
-  onBeforePickRender: (material: PointCloudMaterial, renterTarget: WebGLRenderTarget) => void;
-}
-
-interface IPickState {
-  renderTarget: WebGLRenderTarget;
-  material: PointCloudMaterial;
-  scene: Scene;
-}
-
-const helperVec3 = new Vector3();
 
 export class PointCloudOctree extends PointCloudTree {
   potree: IPotree;
@@ -81,8 +29,7 @@ export class PointCloudOctree extends PointCloudTree {
   numVisiblePoints: number = 0;
   showBoundingBox: boolean = false;
   private visibleBounds: Box3 = new Box3();
-  private visibleNodeTextureOffsets = new Map<string, number>();
-  private pickState: IPickState | undefined;
+  private picker: PointCloudOctreePicker | undefined;
 
   constructor(
     potree: IPotree,
@@ -129,12 +76,10 @@ export class PointCloudOctree extends PointCloudTree {
 
     this.visibleNodes = [];
     this.visibleGeometry = [];
-    this.visibleNodeTextureOffsets.clear();
 
-    if (this.pickState) {
-      this.pickState.material.dispose();
-      this.pickState.renderTarget.dispose();
-      this.pickState = undefined;
+    if (this.picker) {
+      this.picker.dispose();
+      this.picker = undefined;
     }
 
     this.disposed = true;
@@ -157,7 +102,7 @@ export class PointCloudOctree extends PointCloudTree {
     points.name = geometryNode.name;
     points.position.copy(geometryNode.boundingBox.min);
     points.frustumCulled = false;
-    points.onBeforeRender = this.makeOnBeforeRender(node);
+    points.onBeforeRender = PointCloudMaterial.makeOnBeforeRender(this, node);
 
     if (parent) {
       parent.sceneNode.add(points);
@@ -175,36 +120,6 @@ export class PointCloudOctree extends PointCloudTree {
     }
 
     return node;
-  }
-
-  private makeOnBeforeRender(node: PointCloudOctreeNode) {
-    return (
-      _renderer: WebGLRenderer,
-      _scene: Scene,
-      _camera: Camera,
-      _geometry: Geometry | BufferGeometry,
-      material: Material,
-    ) => {
-      const materialUniforms = (material as PointCloudMaterial).uniforms;
-
-      materialUniforms.level.value = node.level;
-      materialUniforms.isLeafNode.value = node.isLeafNode;
-
-      const vnStart = this.visibleNodeTextureOffsets.get(node.name);
-      if (vnStart !== undefined) {
-        materialUniforms.vnStart.value = vnStart;
-      }
-
-      const pcIndex = node.pcIndex ? node.pcIndex : this.visibleNodes.indexOf(node);
-      materialUniforms.pcIndex.value = pcIndex;
-
-      // Note: when changing uniforms in onBeforeRender, the flag uniformsNeedUpdate has to be
-      // set to true to instruct ThreeJS to upload them. See also
-      // https://github.com/mrdoob/three.js/issues/9870#issuecomment-368750182.
-
-      // Remove the cast to any when uniformsNeedUpdate has been added to the typings.
-      (material as any) /*ShaderMaterial*/.uniformsNeedUpdate = true;
-    };
   }
 
   updateVisibleBounds() {
@@ -240,84 +155,6 @@ export class PointCloudOctree extends PointCloudTree {
     }
 
     bbRoot.children = visibleBoxes;
-  }
-
-  updateMaterial(
-    material: PointCloudMaterial,
-    visibleNodes: PointCloudOctreeNode[],
-    camera: PerspectiveCamera,
-    renderer: WebGLRenderer,
-  ): void {
-    const maxScale = Math.max(this.scale.x, this.scale.y, this.scale.z);
-    const pixelRatio = renderer.getPixelRatio();
-
-    material.fov = camera.fov * (Math.PI / 180);
-    material.screenWidth = renderer.domElement.clientWidth * pixelRatio;
-    material.screenHeight = renderer.domElement.clientHeight * pixelRatio;
-    material.spacing = this.pcoGeometry.spacing * maxScale;
-    material.uniforms.octreeSize.value = this.pcoGeometry.boundingBox.getSize(helperVec3).x;
-
-    if (
-      material.pointSizeType === PointSizeType.ADAPTIVE ||
-      material.pointColorType === PointColorType.LOD
-    ) {
-      this.updateVisibilityTextureData(visibleNodes, material);
-    }
-  }
-
-  private updateVisibilityTextureData(nodes: PointCloudOctreeNode[], material: PointCloudMaterial) {
-    nodes.sort(byLevelAndIndex);
-
-    const data = new Uint8Array(nodes.length * 4);
-    const offsetsToChild = new Array(nodes.length).fill(Infinity);
-
-    this.visibleNodeTextureOffsets.clear();
-
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-
-      this.visibleNodeTextureOffsets.set(node.name, i);
-
-      if (i > 0) {
-        const parentName = node.name.slice(0, -1);
-        const parentOffset = this.visibleNodeTextureOffsets.get(parentName)!;
-        const parentOffsetToChild = i - parentOffset;
-
-        offsetsToChild[parentOffset] = Math.min(offsetsToChild[parentOffset], parentOffsetToChild);
-
-        // tslint:disable:no-bitwise
-        const offset = parentOffset * 4;
-        data[offset] = data[offset] | (1 << node.index);
-        data[offset + 1] = offsetsToChild[parentOffset] >> 8;
-        data[offset + 2] = offsetsToChild[parentOffset] % 256;
-        // tslint:enable:no-bitwise
-      }
-
-      data[i * 4 + 3] = node.name.length;
-    }
-
-    const texture = material.visibleNodesTexture;
-    if (texture) {
-      texture.image.data.set(data);
-      texture.needsUpdate = true;
-    }
-  }
-
-  private helperSphere = new Sphere();
-
-  nodesOnRay(nodes: PointCloudOctreeNode[], ray: Ray): PointCloudOctreeNode[] {
-    const nodesOnRay: PointCloudOctreeNode[] = [];
-
-    const rayClone = ray.clone();
-    for (const node of nodes) {
-      const sphere = this.helperSphere.copy(node.boundingSphere).applyMatrix4(this.matrixWorld);
-
-      if (rayClone.intersectsSphere(sphere)) {
-        nodesOnRay.push(node);
-      }
-    }
-
-    return nodesOnRay;
   }
 
   updateMatrixWorld(force: boolean): void {
@@ -377,249 +214,12 @@ export class PointCloudOctree extends PointCloudTree {
 
   pick(
     renderer: WebGLRenderer,
-    camera: PerspectiveCamera,
+    camera: Camera,
     ray: Ray,
     params: Partial<PickParams> = {},
   ): PickPoint | null {
-    const pixelRatio = renderer.getPixelRatio();
-    const pickWndSize = Math.floor(
-      (params.pickWindowSize || DEFAULT_PICK_WINDOW_SIZE) * pixelRatio,
-    );
-
-    const width = Math.ceil(renderer.domElement.clientWidth * pixelRatio);
-    const height = Math.ceil(renderer.domElement.clientHeight * pixelRatio);
-
-    const pickState = this.pickState ? this.pickState : (this.pickState = this.getPickState());
-    const pickMaterial = pickState.material;
-
-    // Get all the octree nodes which intersect the picking ray. We only need to render those.
-    const nodes: PointCloudOctreeNode[] = this.nodesOnRay(this.visibleNodes, ray);
-    if (nodes.length === 0) {
-      return null;
-    }
-
-    // Create copies of the nodes so we can render them differently than in the normal point cloud.
-    const tempNodes = [];
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      node.pcIndex = i + 1;
-
-      const sceneNode = node.sceneNode;
-      const tempNode = new Points(sceneNode.geometry, pickMaterial);
-      tempNode.matrix = sceneNode.matrix;
-      tempNode.matrixWorld = sceneNode.matrixWorld;
-      tempNode.matrixAutoUpdate = false;
-      tempNode.frustumCulled = false;
-      (tempNode as any).pcIndex = i + 1;
-      tempNode.onBeforeRender = this.makeOnBeforeRender(node);
-
-      tempNodes.push(tempNode);
-    }
-
-    pickState.scene.autoUpdate = false;
-    pickState.scene.children = tempNodes;
-
-    this.updatePickMaterial(pickMaterial, params);
-    this.updateMaterial(pickMaterial, nodes, camera, renderer);
-    this.updatePickRenderTarget(this.pickState, width, height);
-
-    if (params.onBeforePickRender) {
-      params.onBeforePickRender(pickMaterial, pickState.renderTarget);
-    }
-
-    const pixelPosition = helperVec3; // Use helper vector to prevent extra allocations.
-
-    if (params.pixelPosition) {
-      pixelPosition.copy(params.pixelPosition);
-    } else {
-      pixelPosition.addVectors(camera.position, ray.direction).project(camera);
-      pixelPosition.x = (pixelPosition.x + 1) * width * 0.5;
-      pixelPosition.y = (pixelPosition.y + 1) * height * 0.5;
-    }
-
-    const halfPickWndSize = (pickWndSize - 1) / 2;
-    const x = Math.floor(clamp(pixelPosition.x - halfPickWndSize, 0, width));
-    const y = Math.floor(clamp(pixelPosition.y - halfPickWndSize, 0, height));
-
-    // Render the intersected nodes onto the pick render target, clipping to a small pick window.
-    renderer.setScissor(x, y, pickWndSize, pickWndSize);
-    renderer.setScissorTest(true);
-    renderer.state.buffers.depth.setTest(pickMaterial.depthTest);
-    renderer.state.buffers.depth.setMask(pickMaterial.depthWrite ? true : false);
-    renderer.state.setBlending(NoBlending);
-
-    renderer.setRenderTarget(pickState.renderTarget);
-
-    // Save the current clear color and clear the renderer with black color and alpha 0.
-    const oldClearColor = renderer.getClearColor();
-    const oldClearAlpha = renderer.getClearAlpha();
-    renderer.setClearColor(COLOR_BLACK, 0);
-    renderer.clear(true, true, true);
-    renderer.setClearColor(oldClearColor, oldClearAlpha);
-
-    renderer.render(pickState.scene, camera);
-
-    // Read the pixel from the pick render target.
-    const pixels = new Uint8Array(4 * pickWndSize * pickWndSize);
-    renderer.readRenderTargetPixels(pickState.renderTarget, x, y, pickWndSize, pickWndSize, pixels);
-    renderer.setScissorTest(false);
-    renderer.setRenderTarget(null!);
-
-    const ibuffer = new Uint32Array(pixels.buffer);
-
-    // Find closest hit inside pixelWindow boundaries
-    let min = Number.MAX_VALUE;
-    let hit: PointCloudHit | null = null;
-    for (let u = 0; u < pickWndSize; u++) {
-      for (let v = 0; v < pickWndSize; v++) {
-        const offset = u + v * pickWndSize;
-        const distance =
-          Math.pow(u - (pickWndSize - 1) / 2, 2) + Math.pow(v - (pickWndSize - 1) / 2, 2);
-
-        const pcIndex = pixels[4 * offset + 3];
-        pixels[4 * offset + 3] = 0;
-        const pIndex = ibuffer[offset];
-
-        if (pcIndex > 0 && distance < min) {
-          hit = {
-            pIndex: pIndex,
-            pcIndex: pcIndex - 1,
-          };
-          min = distance;
-        }
-      }
-    }
-
-    return this.getPickPoint(hit, nodes);
-  }
-
-  private getPickPoint(hit: PointCloudHit | null, nodes: PointCloudOctreeNode[]): PickPoint | null {
-    if (!hit) {
-      return null;
-    }
-
-    const point: PickPoint = {};
-
-    const points = nodes[hit.pcIndex] && nodes[hit.pcIndex].sceneNode;
-    if (!points) {
-      return null;
-    }
-
-    const attributes: BufferAttribute[] = (points.geometry as any).attributes;
-
-    for (const property in attributes) {
-      if (!attributes.hasOwnProperty(property)) {
-        continue;
-      }
-
-      const values = attributes[property];
-
-      // tslint:disable-next-line:prefer-switch
-      if (property === 'position') {
-        this.addPositionToPickPoint(point, hit, values, points);
-      } else if (property === 'normal') {
-        this.addNormalToPickPoint(point, hit, values);
-      } else if (property === 'indices') {
-        // TODO
-      } else {
-        if (values.itemSize === 1) {
-          point[property] = values.array[hit.pIndex];
-        } else {
-          const value = [];
-          for (let j = 0; j < values.itemSize; j++) {
-            value.push(values.array[values.itemSize * hit.pIndex + j]);
-          }
-          point[property] = value;
-        }
-      }
-    }
-
-    return point;
-  }
-
-  private addPositionToPickPoint(
-    point: PickPoint,
-    hit: PointCloudHit,
-    values: BufferAttribute,
-    points: Points,
-  ): void {
-    const x = values.array[3 * hit.pIndex];
-    const y = values.array[3 * hit.pIndex + 1];
-    const z = values.array[3 * hit.pIndex + 2];
-
-    point.position = new Vector3(x, y, z).applyMatrix4(points.matrixWorld);
-  }
-
-  private addNormalToPickPoint(
-    point: PickPoint,
-    hit: PointCloudHit,
-    values: BufferAttribute,
-  ): void {
-    const normalsArray = values.array;
-
-    const x = normalsArray[3 * hit.pIndex];
-    const y = normalsArray[3 * hit.pIndex + 1];
-    const z = normalsArray[3 * hit.pIndex + 2];
-
-    const normal = new Vector4(x, y, z, 0);
-    const m = new Matrix4();
-    m.getInverse(this.matrixWorld);
-    m.transpose();
-    normal.applyMatrix4(m);
-
-    point.normal = new Vector3(normal.x, normal.y, normal.z);
-    point.datasetNormal = new Vector3(x, y, z);
-  }
-
-  private getPickState() {
-    const scene = new Scene();
-
-    const material = new PointCloudMaterial();
-    material.pointColorType = PointColorType.POINT_INDEX;
-
-    return {
-      renderTarget: this.makePickRenderTarget(),
-      material: material,
-      scene: scene,
-    };
-  }
-
-  private updatePickMaterial(pickMaterial: PointCloudMaterial, params: Partial<PickParams>): void {
-    const material = this.material;
-
-    pickMaterial.pointSizeType = material.pointSizeType;
-    pickMaterial.shape = material.shape;
-    pickMaterial.size = material.size;
-    pickMaterial.minSize = material.minSize;
-    pickMaterial.maxSize = material.maxSize;
-    pickMaterial.classification = material.classification;
-
-    if (params.pickOutsideClipRegion) {
-      pickMaterial.clipMode = ClipMode.DISABLED;
-    } else {
-      pickMaterial.clipMode = material.clipMode;
-      pickMaterial.setClipBoxes(
-        material.clipMode === ClipMode.CLIP_OUTSIDE ? material.clipBoxes : [],
-      );
-    }
-  }
-
-  private updatePickRenderTarget(pickState: IPickState, width: number, height: number): void {
-    if (pickState.renderTarget.width === width && pickState.renderTarget.height === height) {
-      return;
-    }
-
-    pickState.renderTarget.dispose();
-    pickState.renderTarget = this.makePickRenderTarget();
-    pickState.renderTarget.setSize(width, height);
-  }
-
-  private makePickRenderTarget() {
-    return new WebGLRenderTarget(1, 1, {
-      minFilter: LinearFilter,
-      magFilter: NearestFilter,
-      format: RGBAFormat,
-    });
+    this.picker = this.picker || new PointCloudOctreePicker();
+    return this.picker.pick(renderer, camera, ray, [this], params);
   }
 
   get progress() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,6 @@ export interface IPotree {
 export interface PickPoint {
   position?: Vector3;
   normal?: Vector3;
-  datasetNormal?: Vector3;
   [property: string]: any;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface IPotree {
 export interface PickPoint {
   position?: Vector3;
   normal?: Vector3;
+  pointCloud?: PointCloudOctree;
   [property: string]: any;
 }
 


### PR DESCRIPTION
This PR adds efficient point picking in multiple point clouds.

Previously, we had to call `pick()` on each cloud separately and merge the pick results back into a single one. The main drawback of this approach is a severe performance hit. We observed around 5 to 10 ms per pick call, almost all the time is spent in `readPixels()`. We can easily have 10 or more point clouds visible at a time, and the picking times just add up, so the frame rate can easily drop below 10 fps or worse.

This PR adds a method `Potree.pick()` that operates on multiple clouds at the same time. It renders them all to the same render target and calls `readPixels()` only once. In my test scenario with 15 point clouds, the time for picking dropped from 65 ms to 7 ms.

There are also a few minor things I changed / fixed in this PR:
* The `pick()` method now accepts `Camera` instead of `PerspectiveCamera`, i.e., it also works for `OrthographicCamera`
* The material properties `useFilterByNormal` and `filterByNormalThreshold` are now copied to the pick material to ensure they are applied during picking
* I dropped the `datasetNormal` field from the pick result (i.e. the untransformed normal) - we don't use it anymore and it can be recovered easily when needed; also it was inconsistent because no such field existed for the coordinate
* The `near` and `far` uniforms were not used in the shaders so I removed them
* If an orthographic camera was combined with attenuated or adaptive size mode, an undefined `fov` value would have been sent to the shader
* An error message is logged to the console if more than 255 nodes take part in the picking as we have only 8 bits minus the value 0 available - this could have happened before, as well, but is more likely to happen with multiple clouds
* The "point index" color type in the visible rendering was probably broken once picking had been used, because in https://github.com/pnext/three-loader/blob/master/src/point-cloud-octree.ts#L407 `node.pcIndex` is set so in https://github.com/pnext/three-loader/blob/master/src/point-cloud-octree.ts#L198 we would no longer use `this.visibleNodes.indexOf(node)` for this node
* Mainly in preparation to the refactoring, I made many methods that didn't access members `static`
