### PR TITLE
changed getInverse() [deprecated] to copy().invert()

### DIFF
--- a/src/potree.ts
+++ b/src/potree.ts
@@ -348,7 +348,7 @@ export class Potree implements IPotree {
         frustums.push(new Frustum().setFromProjectionMatrix(frustumMatrix));
 
         // Camera position in object space
-        inverseWorldMatrix.getInverse(worldMatrix);
+        inverseWorldMatrix.copy(worldMatrix).invert();
         cameraMatrix
           .identity()
           .multiply(inverseWorldMatrix)


### PR DESCRIPTION
### three js version compatibility

![image](https://user-images.githubusercontent.com/27716524/110905505-e99c7f00-834d-11eb-8254-a7726d28a69e.png)
Remove annoying warning from usage of deprecated `getInverse()` function
changed to substitute `copy().invert()`