### PR TITLE
Loader worker pool

### DIFF
--- a/src/loading/binary-loader.ts
+++ b/src/loading/binary-loader.ts
@@ -5,6 +5,7 @@
 import { Box3, BufferAttribute, BufferGeometry, Uint8BufferAttribute, Vector3 } from 'three';
 import { PointAttributeName, PointAttributeType } from '../point-attributes';
 import { PointCloudOctreeGeometryNode } from '../point-cloud-octree-geometry-node';
+import { WorkerPool } from '../utils/worker-pool';
 import { Version } from '../version';
 import { GetUrlFn, XhrRequest } from './types';
 
@@ -46,7 +47,10 @@ export class BinaryLoader {
   xhrRequest: XhrRequest;
   callbacks: Callback[];
 
-  private workers: Worker[] = [];
+  private static readonly WORKER_POOL = new WorkerPool(
+    32,
+    require('../workers/binary-decoder.worker.js'),
+  );
 
   constructor({
     getUrl = s => Promise.resolve(s),
@@ -69,9 +73,6 @@ export class BinaryLoader {
   }
 
   dispose(): void {
-    this.workers.forEach(worker => worker.terminate());
-    this.workers = [];
-
     this.disposed = true;
   }
 
@@ -107,71 +108,56 @@ export class BinaryLoader {
       return;
     }
 
-    const worker = this.getWorker();
+    BinaryLoader.WORKER_POOL.getWorker().then(autoTerminatingWorker => {
+      const pointAttributes = node.pcoGeometry.pointAttributes;
+      const numPoints = buffer.byteLength / pointAttributes.byteSize;
 
-    const pointAttributes = node.pcoGeometry.pointAttributes;
-    const numPoints = buffer.byteLength / pointAttributes.byteSize;
-
-    if (this.version.upTo('1.5')) {
-      node.numPoints = numPoints;
-    }
-
-    worker.onmessage = (e: WorkerResponse) => {
-      if (this.disposed) {
-        resolve();
-        return;
+      if (this.version.upTo('1.5')) {
+        node.numPoints = numPoints;
       }
 
-      const data = e.data;
+      autoTerminatingWorker.worker.onmessage = (e: WorkerResponse) => {
+        if (this.disposed) {
+          resolve();
+          BinaryLoader.WORKER_POOL.releaseWorker(autoTerminatingWorker);
+          return;
+        }
 
-      const geometry = (node.geometry = node.geometry || new BufferGeometry());
-      geometry.boundingBox = node.boundingBox;
+        const data = e.data;
 
-      this.addBufferAttributes(geometry, data.attributeBuffers);
-      this.addIndices(geometry, data.indices);
-      this.addNormalAttribute(geometry, numPoints);
+        const geometry = (node.geometry = node.geometry || new BufferGeometry());
+        geometry.boundingBox = node.boundingBox;
 
-      node.mean = new Vector3().fromArray(data.mean);
-      node.tightBoundingBox = this.getTightBoundingBox(data.tightBoundingBox);
-      node.loaded = true;
-      node.loading = false;
-      node.failed = false;
-      node.pcoGeometry.numNodesLoading--;
-      node.pcoGeometry.needsUpdate = true;
+        this.addBufferAttributes(geometry, data.attributeBuffers);
+        this.addIndices(geometry, data.indices);
+        this.addNormalAttribute(geometry, numPoints);
 
-      this.releaseWorker(worker);
+        node.mean = new Vector3().fromArray(data.mean);
+        node.tightBoundingBox = this.getTightBoundingBox(data.tightBoundingBox);
+        node.loaded = true;
+        node.loading = false;
+        node.failed = false;
+        node.pcoGeometry.numNodesLoading--;
+        node.pcoGeometry.needsUpdate = true;
 
-      this.callbacks.forEach(callback => callback(node));
-      resolve();
-    };
+        this.callbacks.forEach(callback => callback(node));
+        resolve();
+        BinaryLoader.WORKER_POOL.releaseWorker(autoTerminatingWorker);
+      };
 
-    const message = {
-      buffer,
-      pointAttributes,
-      version: this.version.version,
-      min: node.boundingBox.min.toArray(),
-      offset: node.pcoGeometry.offset.toArray(),
-      scale: this.scale,
-      spacing: node.spacing,
-      hasChildren: node.hasChildren,
-    };
+      const message = {
+        buffer,
+        pointAttributes,
+        version: this.version.version,
+        min: node.boundingBox.min.toArray(),
+        offset: node.pcoGeometry.offset.toArray(),
+        scale: this.scale,
+        spacing: node.spacing,
+        hasChildren: node.hasChildren,
+      };
 
-    worker.postMessage(message, [message.buffer]);
-  }
-
-  private getWorker(): Worker {
-    const worker = this.workers.pop();
-    if (worker) {
-      return worker;
-    }
-
-    const ctor = require('../workers/binary-decoder.worker.js');
-
-    return new ctor();
-  }
-
-  private releaseWorker(worker: Worker): void {
-    this.workers.push(worker);
+      autoTerminatingWorker.worker.postMessage(message, [message.buffer]);
+    });
   }
 
   private getTightBoundingBox({ min, max }: { min: number[]; max: number[] }): Box3 {

--- a/src/loading/binary-loader.ts
+++ b/src/loading/binary-loader.ts
@@ -47,7 +47,7 @@ export class BinaryLoader {
   xhrRequest: XhrRequest;
   callbacks: Callback[];
 
-  private static readonly WORKER_POOL = new WorkerPool(
+  public static readonly WORKER_POOL = new WorkerPool(
     32,
     require('../workers/binary-decoder.worker.js'),
   );

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -17,7 +17,7 @@ import {
   PERSPECTIVE_CAMERA,
 } from './constants';
 import { FEATURES } from './features';
-import { GetUrlFn, loadPOC } from './loading';
+import { BinaryLoader, GetUrlFn, loadPOC } from './loading';
 import { ClipMode } from './materials';
 import { PointCloudOctree } from './point-cloud-octree';
 import { PointCloudOctreeGeometryNode } from './point-cloud-octree-geometry-node';
@@ -99,6 +99,14 @@ export class Potree implements IPotree {
       this.lru.pointBudget = value;
       this.lru.freeMemory();
     }
+  }
+
+  static set maxLoaderWorkers(value: number) {
+    BinaryLoader.WORKER_POOL.maxWorkers = value;
+  }
+
+  static get maxLoaderWorkers(): number {
+    return BinaryLoader.WORKER_POOL.maxWorkers;
   }
 
   private updateVisibility(

--- a/src/utils/async-blocking-queue.ts
+++ b/src/utils/async-blocking-queue.ts
@@ -1,0 +1,32 @@
+export class AsyncBlockingQueue<T> {
+  private promises: Promise<T>[];
+  private resolvers: ((t: T) => void)[];
+
+  constructor() {
+    this.resolvers = [];
+    this.promises = [];
+  }
+
+  public enqueue(t: T): void {
+    if (!this.resolvers.length) {
+      this.add();
+    }
+    const resolve = this.resolvers.shift()!;
+    resolve(t);
+  }
+
+  public dequeue(): Promise<T> {
+    if (!this.promises.length) {
+      this.add();
+    }
+    return this.promises.shift()!;
+  }
+
+  private add(): void {
+    this.promises.push(
+      new Promise(resolve => {
+        this.resolvers.push(resolve);
+      }),
+    );
+  }
+}

--- a/src/utils/worker-pool.ts
+++ b/src/utils/worker-pool.ts
@@ -37,7 +37,7 @@ export class WorkerPool {
   private pool = new AsyncBlockingQueue<AutoTerminatingWorker>();
   private poolSize = 0;
 
-  constructor(private maxWorkers: number, private workerType: any) {}
+  constructor(public maxWorkers: number, private workerType: any) {}
 
   /**
    * Returns a worker promise which is resolved when one is available.

--- a/src/utils/worker-pool.ts
+++ b/src/utils/worker-pool.ts
@@ -1,0 +1,74 @@
+import { AsyncBlockingQueue } from './async-blocking-queue';
+
+export class AutoTerminatingWorker {
+  private timeoutId: number | undefined = undefined;
+  private terminated: boolean = false;
+
+  constructor(private wrappedWorker: Worker, private maxIdle: number) {}
+
+  public get worker(): Worker {
+    return this.wrappedWorker;
+  }
+
+  get isTerminated(): boolean {
+    return this.terminated;
+  }
+
+  markIdle(): void {
+    this.timeoutId = window.setTimeout(() => {
+      this.terminated = true;
+      this.wrappedWorker.terminate();
+    }, this.maxIdle);
+  }
+
+  markInUse(): void {
+    if (this.timeoutId) {
+      window.clearTimeout(this.timeoutId);
+    }
+  }
+}
+
+export class WorkerPool {
+  /**
+   * The maximum amount of idle time that can elapse before a worker from this pool is automatically terminated
+   */
+  private static readonly POOL_MAX_IDLE = 7000;
+
+  private pool = new AsyncBlockingQueue<AutoTerminatingWorker>();
+  private poolSize = 0;
+
+  constructor(private maxWorkers: number, private workerType: any) {}
+
+  /**
+   * Returns a worker promise which is resolved when one is available.
+   */
+  public getWorker(): Promise<AutoTerminatingWorker> {
+    // If the number of active workers is smaller than the maximum, return a new one.
+    // Otherwise, return a promise for worker from the pool.
+    if (this.poolSize < this.maxWorkers) {
+      this.poolSize++;
+      return Promise.resolve(
+        new AutoTerminatingWorker(new this.workerType(), WorkerPool.POOL_MAX_IDLE),
+      );
+    } else {
+      return this.pool.dequeue().then(worker => {
+        worker.markInUse();
+        // If the dequeued worker has been terminated, decrease the pool size and make a recursive call to get a new worker
+        if (worker.isTerminated) {
+          this.poolSize--;
+          return this.getWorker();
+        }
+        return worker;
+      });
+    }
+  }
+
+  /**
+   * Releases a Worker back into the pool
+   * @param worker
+   */
+  public releaseWorker(worker: AutoTerminatingWorker): void {
+    worker.markIdle();
+    this.pool.enqueue(worker);
+  }
+}


### PR DESCRIPTION
Fixed an issue where Chromium based browsers will crash because of too many web workers when loading a large number of pointclouds at once.
The problem is fixed by utilizing a pool of reusable and self-terminating workers.