### PR TITLE
added screen space clipping

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -1,5 +1,5 @@
 import { Vector3 } from 'three';
-import { PointCloudOctree } from '../src';
+import { ClipMode, PointCloudOctree } from '../src';
 import { Viewer } from './viewer';
 
 require('./main.css');
@@ -44,6 +44,9 @@ loadBtn.addEventListener('click', () => {
       pointCloud = pco;
       pointCloud.rotateX(-Math.PI / 2);
       pointCloud.material.size = 1.0;
+
+      pointCloud.material.clipMode = ClipMode.CLIP_HORIZONTALLY;
+      pointCloud.material.clipExtent = [0.0, 0.0, 0.5, 1.0];
 
       const camera = viewer.camera;
       camera.far = 1000;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnext/three-loader",
   "private": false,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>"

--- a/src/materials/clipping.ts
+++ b/src/materials/clipping.ts
@@ -4,6 +4,8 @@ export enum ClipMode {
   DISABLED = 0,
   CLIP_OUTSIDE = 1,
   HIGHLIGHT_INSIDE = 2,
+  CLIP_HORIZONTALLY = 3,
+  CLIP_VERTICALLY = 4,
 }
 
 export interface IClipBox {

--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -61,6 +61,7 @@ export interface IPointCloudMaterialUniforms {
   classificationLUT: IUniform<Texture>;
   clipBoxCount: IUniform<number>;
   clipBoxes: IUniform<Float32Array>;
+  clipExtent: IUniform<[number, number, number, number]>;
   depthMap: IUniform<Texture | null>;
   diffuse: IUniform<[number, number, number]>;
   fov: IUniform<number>;
@@ -156,6 +157,8 @@ const CLIP_MODE_DEFS = {
   [ClipMode.DISABLED]: 'clip_disabled',
   [ClipMode.CLIP_OUTSIDE]: 'clip_outside',
   [ClipMode.HIGHLIGHT_INSIDE]: 'clip_highlight_inside',
+  [ClipMode.CLIP_HORIZONTALLY]: 'clip_horizontally',
+  [ClipMode.CLIP_VERTICALLY]: 'clip_vertically',
 };
 
 export class PointCloudMaterial extends RawShaderMaterial {
@@ -189,6 +192,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
     classificationLUT: makeUniform('t', this.classificationTexture || new Texture()),
     clipBoxCount: makeUniform('f', 0),
     clipBoxes: makeUniform('Matrix4fv', [] as any),
+    clipExtent: makeUniform('fv', [0.0, 1.0, 0.0, 1.0] as [number, number, number, number]),
     depthMap: makeUniform('t', null),
     diffuse: makeUniform('fv', [1, 1, 1] as [number, number, number]),
     fov: makeUniform('f', 1.0),
@@ -243,6 +247,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
   };
 
   @uniform('bbSize') bbSize!: [number, number, number];
+  @uniform('clipExtent') clipExtent!: [number, number, number, number];
   @uniform('depthMap') depthMap!: Texture | undefined;
   @uniform('fov') fov!: number;
   @uniform('heightMax') heightMax!: number;

--- a/src/materials/shaders/pointcloud.frag
+++ b/src/materials/shaders/pointcloud.frag
@@ -21,6 +21,10 @@ uniform float screenHeight;
 
 uniform sampler2D depthMap;
 
+#if defined (clip_horizontally) || defined (clip_vertically)
+	uniform vec4 clipExtent;
+#endif
+
 #ifdef use_texture_blending
 	uniform sampler2D backgroundMap;
 #endif
@@ -76,6 +80,20 @@ float specularStrength = 1.0;
 void main() {
 	vec3 color = vColor;
 	float depth = gl_FragCoord.z;
+
+	#if defined (clip_horizontally) || defined (clip_vertically)
+	vec2 ndc = vec2((gl_FragCoord.x / screenWidth), 1.0 - (gl_FragCoord.y / screenHeight));
+
+	if(step(clipExtent.x, ndc.x) * step(ndc.x, clipExtent.z) < 1.0)
+	{
+		discard;
+	}
+
+	if(step(clipExtent.y, ndc.y) * step(ndc.y, clipExtent.w) < 1.0)
+	{
+		discard;
+	}
+	#endif  
 
 	#if defined(circle_point_shape) || defined(paraboloid_point_shape) || defined (weighted_splats)
 		float u = 2.0 * gl_PointCoord.x - 1.0;


### PR DESCRIPTION
Initial support for clipping of points in screen space. Which parts to clip/discard and what other parts of a point cloud to render is defined as a rectangular region in normalized device coordinates on a per material basis. This means multiple datasets can be rendered and displayed in a side-by-side fashion by defining the appropriate rectangular region of its material.

Clipping can be performed horizontally as well as vertically.

![150797791-75c18f77-3007-4e1e-8926-935b2efe0840](https://user-images.githubusercontent.com/1718257/166412266-577c9580-c2a3-42c5-ba99-d8b7cd12eaa7.png)

Same as https://github.com/pnext/three-loader/pull/103 but cleaned up.

