### PR TITLE
feat: sign urls for s3 reads

### DIFF
--- a/src/loading2/load-octree.ts
+++ b/src/loading2/load-octree.ts
@@ -7,7 +7,8 @@ export async function loadOctree(
 	xhrRequest: XhrRequest,
 ) {
 	const trueUrl = await getUrl(url);
-	const loader = new OctreeLoader();
+
+	const loader = new OctreeLoader(getUrl, url);
 	const {geometry} = await loader.load(trueUrl, xhrRequest);
 
 	return geometry;


### PR DESCRIPTION
Re-sign the individual URLs for the `hierarchy.bin` and the `octree.bin` for reading from private S3 buckets.