### PR TITLE
fix: offset for tight box

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnext/three-loader",
   "private": false,
-  "version": "0.3.5-dev.1",
+  "version": "0.3.5-dev.3",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnext/three-loader",
   "private": false,
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>"

--- a/src/loading2/octree-loader.ts
+++ b/src/loading2/octree-loader.ts
@@ -479,7 +479,7 @@ export class OctreeLoader {
 			);
 		}
 
-		const offset = metadata.offset;
+		const offset = metadata.boundingBox.min;
 		const tightBoundingBox = new Box3(
 			new Vector3(
 				positionAttribute.min[0] - offset[0],

--- a/src/loading2/octree-loader.ts
+++ b/src/loading2/octree-loader.ts
@@ -446,7 +446,6 @@ export class OctreeLoader {
 
 		octree.projection = metadata.projection;
 		octree.boundingBox = boundingBox;
-		octree.tightBoundingBox = boundingBox.clone();
 		octree.boundingSphere = boundingBox.getBoundingSphere(new Sphere());
 		octree.tightBoundingSphere = boundingBox.getBoundingSphere(new Sphere());
 		octree.offset = offset;


### PR DESCRIPTION
Use bounds min as offset for tight bounding box calculation rather than offset from the metadata.json. 