### PR TITLE
refactor: bump version to 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnext/three-loader",
   "private": false,
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>"


### PR DESCRIPTION
Bump version to `0.3.9` so that recent https://github.com/pnext/three-loader/pull/157 can be published