### PR TITLE
Filter by classification

### DIFF
--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -99,6 +99,7 @@ export interface IPointCloudMaterialUniforms {
   wSourceID: IUniform<number>;
   opacityAttenuation: IUniform<number>;
   filterByNormalThreshold: IUniform<number>;
+  classificationFilter: IUniform<boolean[]>;
   highlightedPointCoordinate: IUniform<Vector3>;
   highlightedPointColor: IUniform<Vector4>;
   enablePointHighlighting: IUniform<boolean>;
@@ -233,6 +234,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
     wSourceID: makeUniform('f', 0),
     opacityAttenuation: makeUniform('f', 1),
     filterByNormalThreshold: makeUniform('f', 0),
+    classificationFilter: makeUniform('iv', new Array(256).fill(false)),
     highlightedPointCoordinate: makeUniform('fv', new Vector3()),
     highlightedPointColor: makeUniform('fv', DEFAULT_HIGHLIGHT_COLOR.clone()),
     enablePointHighlighting: makeUniform('b', true),
@@ -279,6 +281,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
   @uniform('wSourceID') weightSourceID!: number;
   @uniform('opacityAttenuation') opacityAttenuation!: number;
   @uniform('filterByNormalThreshold') filterByNormalThreshold!: number;
+  @uniform('classificationFilter') classificationFilter!: boolean[];
   @uniform('highlightedPointCoordinate') highlightedPointCoordinate!: Vector3;
   @uniform('highlightedPointColor') highlightedPointColor!: Vector4;
   @uniform('enablePointHighlighting') enablePointHighlighting!: boolean;
@@ -303,6 +306,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
   @requiresShaderUpdate() treeType: TreeType = TreeType.OCTREE;
   @requiresShaderUpdate() pointOpacityType: PointOpacityType = PointOpacityType.FIXED;
   @requiresShaderUpdate() useFilterByNormal: boolean = false;
+  @requiresShaderUpdate() useFilterByClassification: boolean = false;
   @requiresShaderUpdate() useTextureBlending: boolean = false;
   @requiresShaderUpdate() usePointCloudMixing: boolean = false;
   @requiresShaderUpdate() highlightPoint: boolean = false;
@@ -434,6 +438,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
     if (this.useFilterByNormal) {
       define('use_filter_by_normal');
+    }
+
+    if (this.useFilterByClassification) {
+      define('use_filter_by_classification');
     }
 
     if (this.useEDL) {

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -98,6 +98,10 @@ uniform sampler2D depthMap;
 	uniform int normalFilteringMode;
 #endif
 
+#ifdef use_filter_by_classification
+	uniform bool classificationFilter[256];
+#endif
+
 varying vec3 vColor;
 
 #if !defined(color_type_point_index)
@@ -507,6 +511,20 @@ void main() {
 		{
 			gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
 		}
+	#endif
+
+	#ifdef use_filter_by_classification
+	
+		int classIndex = int(classification);
+		bool discardPoint = !classificationFilter[classIndex];
+
+		if (discardPoint) {
+			gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+			return;
+		}
+
+
+
 	#endif
 
 	// ---------------------

--- a/src/point-cloud-octree-picker.ts
+++ b/src/point-cloud-octree-picker.ts
@@ -267,6 +267,7 @@ export class PointCloudOctreePicker {
     pickMaterial.maxSize = nodeMaterial.maxSize;
     pickMaterial.classification = nodeMaterial.classification;
     pickMaterial.useFilterByNormal = nodeMaterial.useFilterByNormal;
+    pickMaterial.classificationFilter = nodeMaterial.classificationFilter;
     pickMaterial.useFilterByClassification = nodeMaterial.useFilterByClassification;
     pickMaterial.filterByNormalThreshold = nodeMaterial.filterByNormalThreshold;
 

--- a/src/point-cloud-octree-picker.ts
+++ b/src/point-cloud-octree-picker.ts
@@ -267,6 +267,7 @@ export class PointCloudOctreePicker {
     pickMaterial.maxSize = nodeMaterial.maxSize;
     pickMaterial.classification = nodeMaterial.classification;
     pickMaterial.useFilterByNormal = nodeMaterial.useFilterByNormal;
+    pickMaterial.useFilterByClassification = nodeMaterial.useFilterByClassification;
     pickMaterial.filterByNormalThreshold = nodeMaterial.filterByNormalThreshold;
 
     if (params.pickOutsideClipRegion) {


### PR DESCRIPTION
allows filtering by classification.
Example code:
// after pointcloud loaded
        pco.material.useFilterByClassification = true;//turn on filter in shader
        pco.material.classificationFilter[0] = true;// show default points.

