### PR TITLE
feat: export library as both umd and esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/pnext/three-loader/issues"
   },
   "license": "MIT",
-  "main": "build/potree.js",
+  "main": "build/potree.cjs",
+  "module": "build/potree.mjs",
   "typings": "build/declarations/index.d.ts",
   "scripts": {
     "clean": "rimraf build",
@@ -24,6 +25,14 @@
     "lint": "tslint --project tsconfig.json",
     "prettier": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.ts\"",
     "prepare-release": "standard-version"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./build/declarations/index.d.ts",
+      "import": "./build/potree.mjs",
+      "default": "./build/potree.cjs"
+    }
   },
   "dependencies": {},
   "peerDependencies": {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,20 +1,38 @@
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const webpack = require('webpack');
-const baseConfig = require('./webpack.config');
 
-module.exports = Object.assign(baseConfig, {
-  stats: 'normal',
-  plugins: [
-    ...baseConfig.plugins,
-    new webpack.DefinePlugin({
-      PRODUCTION: JSON.stringify(true),
-    }),
-    new CircularDependencyPlugin({
-      exclude: /node_modules/,
-      failOnError: true,
-      cwd: process.cwd(),
-    }),
-    new BundleAnalyzerPlugin(),
-  ],
-});
+const umdConfig = require('./webpack.config');
+const esmConfig = require('./webpack.esm.config');
+
+module.exports = [
+  Object.assign(umdConfig, {
+    stats: 'normal',
+    plugins: [
+      ...umdConfig.plugins,
+      new webpack.DefinePlugin({
+        PRODUCTION: JSON.stringify(true),
+      }),
+      new CircularDependencyPlugin({
+        exclude: /node_modules/,
+        failOnError: true,
+        cwd: process.cwd(),
+      }),
+      new BundleAnalyzerPlugin(),
+    ],
+  }),
+  Object.assign(esmConfig, {
+    stats: 'normal',
+    plugins: [
+      ...esmConfig.plugins,
+      new webpack.DefinePlugin({
+        PRODUCTION: JSON.stringify(true),
+      }),
+      new CircularDependencyPlugin({
+        exclude: /node_modules/,
+        failOnError: true,
+        cwd: process.cwd(),
+      }),
+    ],
+  }),
+];

--- a/webpack.esm.config.js
+++ b/webpack.esm.config.js
@@ -1,24 +1,24 @@
 const path = require('path');
 
-const SizePlugin = require('size-plugin');
-
 module.exports = {
-  name: 'umd',
+  name: 'module',
   entry: './src/index.ts',
+  experiments: {
+    outputModule: true,
+  },
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'potree.cjs',
+    filename: 'potree.mjs',
+    module: true,
     library: {
-      type: 'umd',
-      umdNamedDefine: true,
+      type: 'module',
     },
   },
-  devtool: 'eval-cheap-source-map',
   stats: 'errors-only',
   resolve: {
-    extensions: ['.ts', '.tsx', '.js'],
+    extensions: ['.tsx', '.ts', '.js'],
   },
-  externals: ['three'],
+  externals: { three: 'three' },
   module: {
     rules: [
       {
@@ -40,5 +40,5 @@ module.exports = {
       { test: /\.(vs|fs|glsl|vert|frag)$/, loader: 'raw-loader' },
     ],
   },
-  plugins: [new SizePlugin()],
+  plugins: [],
 };


### PR DESCRIPTION
Export the three-loader library as both UMD and ESM. 

Supporting both UMD and ESM will allow new build tools such as Vite to consume the library easier, and enable features such as tree-shaking, while still supporting the existing UMD export that is already used. 

The build now has two configurations, umd and esm. Both outputs are exported in the same build file, with UMD exported as potree.cjs and ESM as potree.mjs

Related issue: https://github.com/pnext/three-loader/issues/15