### PR TITLE
Export library as both UMD and ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/pnext/three-loader/issues"
   },
   "license": "MIT",
-  "main": "build/potree.js",
+  "main": "build/potree.cjs",
+  "module": "build/potree.mjs",
   "typings": "build/declarations/index.d.ts",
   "scripts": {
     "clean": "rimraf build",
@@ -24,6 +25,14 @@
     "lint": "tslint --project tsconfig.json",
     "prettier": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.ts\"",
     "prepare-release": "standard-version"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./build/declarations/index.d.ts",
+      "import": "./build/potree.mjs",
+      "default": "./build/potree.cjs"
+    }
   },
   "dependencies": {},
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "url": "https://github.com/pnext/three-loader/issues"
   },
   "license": "MIT",
-  "main": "build/potree.cjs",
-  "module": "build/potree.mjs",
-  "typings": "build/declarations/index.d.ts",
+  "main": "build/index.cjs",
+  "module": "build/index.mjs",
+  "typings": "build/index.d.ts",
   "scripts": {
     "clean": "rimraf build",
     "start": "webpack --mode development --watch --progress",
@@ -29,9 +29,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./build/declarations/index.d.ts",
-      "import": "./build/potree.mjs",
-      "default": "./build/potree.cjs"
+      "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
+      "require": "./build/index.cjs",
+      "default": "./build/index.cjs"
     }
   },
   "dependencies": {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": "./src/",
     "sourceMap": true,
     "declaration": true,
-    "declarationDir": "build/declarations",
+    "declarationDir": "build/",
     "module": "es2015",
     "moduleResolution": "node",
     "strict": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   entry: './src/index.ts',
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'potree.cjs',
+    filename: 'index.cjs',
     library: {
       type: 'umd',
       umdNamedDefine: true,
@@ -17,6 +17,10 @@ module.exports = {
   stats: 'errors-only',
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
+    fallback: {
+      fs: false,
+      path: false,
+    },
   },
   externals: ['three'],
   module: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,20 +1,38 @@
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const webpack = require('webpack');
-const baseConfig = require('./webpack.config');
 
-module.exports = Object.assign(baseConfig, {
-  stats: 'normal',
-  plugins: [
-    ...baseConfig.plugins,
-    new webpack.DefinePlugin({
-      PRODUCTION: JSON.stringify(true),
-    }),
-    new CircularDependencyPlugin({
-      exclude: /node_modules/,
-      failOnError: true,
-      cwd: process.cwd(),
-    }),
-    new BundleAnalyzerPlugin(),
-  ],
-});
+const umdConfig = require('./webpack.config');
+const esmConfig = require('./webpack.esm.config');
+
+module.exports = [
+  Object.assign(umdConfig, {
+    stats: 'normal',
+    plugins: [
+      ...umdConfig.plugins,
+      new webpack.DefinePlugin({
+        PRODUCTION: JSON.stringify(true),
+      }),
+      new CircularDependencyPlugin({
+        exclude: /node_modules/,
+        failOnError: true,
+        cwd: process.cwd(),
+      }),
+      new BundleAnalyzerPlugin(),
+    ],
+  }),
+  Object.assign(esmConfig, {
+    stats: 'normal',
+    plugins: [
+      ...esmConfig.plugins,
+      new webpack.DefinePlugin({
+        PRODUCTION: JSON.stringify(true),
+      }),
+      new CircularDependencyPlugin({
+        exclude: /node_modules/,
+        failOnError: true,
+        cwd: process.cwd(),
+      }),
+    ],
+  }),
+];

--- a/webpack.esm.config.js
+++ b/webpack.esm.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'potree.mjs',
+    filename: 'index.mjs',
     module: true,
     library: {
       type: 'module',
@@ -17,6 +17,10 @@ module.exports = {
   stats: 'errors-only',
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      fs: false,
+      path: false,
+    },
   },
   externals: { three: 'three' },
   module: {

--- a/webpack.esm.config.js
+++ b/webpack.esm.config.js
@@ -1,24 +1,24 @@
 const path = require('path');
 
-const SizePlugin = require('size-plugin');
-
 module.exports = {
-  name: 'umd',
+  name: 'module',
   entry: './src/index.ts',
+  experiments: {
+    outputModule: true,
+  },
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'potree.cjs',
+    filename: 'potree.mjs',
+    module: true,
     library: {
-      type: 'umd',
-      umdNamedDefine: true,
+      type: 'module',
     },
   },
-  devtool: 'eval-cheap-source-map',
   stats: 'errors-only',
   resolve: {
-    extensions: ['.ts', '.tsx', '.js'],
+    extensions: ['.tsx', '.ts', '.js'],
   },
-  externals: ['three'],
+  externals: { three: 'three' },
   module: {
     rules: [
       {
@@ -40,5 +40,5 @@ module.exports = {
       { test: /\.(vs|fs|glsl|vert|frag)$/, loader: 'raw-loader' },
     ],
   },
-  plugins: [new SizePlugin()],
+  plugins: [],
 };


### PR DESCRIPTION
This PR adds support to export the library in both UMD and ESM format. 

Now the build system exports UMD format (index.cjs), ESM format (index.mjs), and types at the root level. Exporting types at the root build level allows IDEs such as VSCode to find the typings when three-loader is used as a git submodule. 