### PR TITLE
fix: use provided xhrRequest when loading Potree2 hierarchy and octree

### DIFF
--- a/src/loading2/octree-loader.ts
+++ b/src/loading2/octree-loader.ts
@@ -87,8 +87,11 @@ export class NodeLoader {
 					buffer = new ArrayBuffer(0);
 					console.warn(`loaded node with 0 bytes: ${node.name}`);
 				} else {
-					const headers = { Range: `bytes=${first}-${last}` };
-					const response = await this.xhrRequest(urlOctree, { headers });
+					// Add byte range as query param to enforce unique cacheable URI
+					const urlOctreeCacheable = `${urlOctree}?range=${first}to${last}`;
+
+					const headers = { Range: `bytes=${first}-${last}`, 'content-type': 'multipart/byteranges' };
+					const response = await this.xhrRequest(urlOctreeCacheable, { headers });
 
 					buffer = await response.arrayBuffer();
 				}


### PR DESCRIPTION
For Potree1 models we are able to provide a custom xhrRequest that is used when requesting any of the resources associated with the model. This is particularly useful when trying to add custom authentication headers to the requests.

Potree2 models are loaded with the same API, however currently the xhrRequest that is passed in is only used for loading the metadata.json file and is not used for fetching the octree.bin or hierarchy.bin files. This means that we cannot use authentication headers for loading these bin files. 

This PR is to fix that, so we are able to use custom headers for Potree2 models, the same way we can for Potree1 models.