### PR TITLE
Potree2 Static Worker Pool

### DIFF
--- a/src/loading2/octree-loader.ts
+++ b/src/loading2/octree-loader.ts
@@ -371,7 +371,7 @@ export interface Metadata {
 
 export class OctreeLoader {
 
-	workerPool: WorkerPool = new WorkerPool();
+	static workerPool: WorkerPool = new WorkerPool();
 
 	basePath = '';
 	hierarchyPath = '';
@@ -480,7 +480,7 @@ export class OctreeLoader {
 	}
 
 	private createLoader(url: string, metadata: Metadata, attributes: any): NodeLoader {
-		const loader = new NodeLoader(this.getUrl, url, this.workerPool, metadata);
+		const loader = new NodeLoader(this.getUrl, url, OctreeLoader.workerPool, metadata);
 		loader.attributes = attributes;
 		loader.scale = metadata.scale;
 		loader.offset = metadata.offset;


### PR DESCRIPTION
The simple solution to issue https://github.com/pnext/three-loader/issues/180.

Instead of generating a new worker pool for each OctreeLoader, create a single static WorkerPool and reuse it everytime a pointcloud is loaded