### PR TITLE
PointCloud pick with an Orthographic camera does not use mouse position.

### DIFF
--- a/src/point-cloud-octree-picker.ts
+++ b/src/point-cloud-octree-picker.ts
@@ -94,7 +94,7 @@ export class PointCloudOctreePicker {
     if (params.pixelPosition) {
       pixelPosition.copy(params.pixelPosition);
     } else {
-      pixelPosition.addVectors(camera.position, ray.direction).project(camera);
+      pixelPosition.addVectors(ray.origin, ray.direction).project(camera);
       pixelPosition.x = (pixelPosition.x + 1) * width * 0.5;
       pixelPosition.y = (pixelPosition.y + 1) * height * 0.5;
     }


### PR DESCRIPTION
`PointCloudPicker.pick` does not work for Orthographic cameras.

Typically when raycasting, the picking ray is generated using the ThreeJS method `raycaster.setFromCamera(coords, camera)`. When this method is called with an Orthographic camera, the ray.direction will be the camera direction, and the ray.origin will be based on where the mouse is on the screen.

This is where the issue comes up. When calculating the pixelPosition in the `pick` method, we use the camera.position and then ray.direction. Therefore, regardless of where the mouse is on the screen, and Orthographic ray will always be projected from the center of the camera. 

The solution here is to use the ray.origin instead of the camera.position to build the correct vector and then project it into camera space. 