### PR TITLE
fix: use xhrRequest for loading Potree2 hierarchy and octree

### DIFF
--- a/src/loading2/decoder.ts
+++ b/src/loading2/decoder.ts
@@ -3,7 +3,7 @@ import { GeometryDecoder } from './geometry-decoder';
 import { OctreeGeometryNode } from './octree-geometry-node';
 import { LoadingContext, Metadata } from './octree-loader';
 import { WorkerType } from './worker-pool';
-import { XhrRequest } from 'loading/types';
+import { XhrRequest } from '../loading/types';
 
 // Buffer files for DEFAULT encoding
 export const HIERARCHY_FILE = 'hierarchy.bin';

--- a/src/loading2/decoder.ts
+++ b/src/loading2/decoder.ts
@@ -3,6 +3,7 @@ import { GeometryDecoder } from './geometry-decoder';
 import { OctreeGeometryNode } from './octree-geometry-node';
 import { LoadingContext, Metadata } from './octree-loader';
 import { WorkerType } from './worker-pool';
+import { XhrRequest } from 'loading/types';
 
 // Buffer files for DEFAULT encoding
 export const HIERARCHY_FILE = 'hierarchy.bin';
@@ -42,7 +43,7 @@ export class Decoder implements GeometryDecoder {
       console.warn(`loaded node with 0 bytes: ${node.name}`);
     } else {
       const headers = { Range: `bytes=${first}-${last}` };
-      const response = await fetch(urlOctree, { headers });
+      const response = await this.xhrRequest(urlOctree, { headers });
 
       buffer = await response.arrayBuffer();
     }
@@ -81,6 +82,10 @@ export class Decoder implements GeometryDecoder {
 
   private get getUrl() {
     return this.context.getUrl;
+  }
+
+  private get xhrRequest(): XhrRequest {
+    return this.context.xhrRequest;
   }
 
   private get octreePath() {

--- a/src/loading2/gltf-decoder.ts
+++ b/src/loading2/gltf-decoder.ts
@@ -1,5 +1,5 @@
 import { BufferAttribute, BufferGeometry } from 'three';
-import { GetUrlFn } from '../loading/types';
+import { GetUrlFn, XhrRequest } from '../loading/types';
 import { DecodedGeometry, GeometryDecoder } from './geometry-decoder';
 import { OctreeGeometryNode } from './octree-geometry-node';
 import { LoadingContext, Metadata } from './octree-loader';
@@ -46,7 +46,7 @@ export class GltfDecoder implements GeometryDecoder {
       const lastPositions = byteOffset * 4n * 3n + byteSize * 4n * 3n - 1n;
 
       const headersPositions = { Range: `bytes=${firstPositions}-${lastPositions}` };
-      const responsePositions = await fetch(urlPositions, { headers: headersPositions });
+      const responsePositions = await this.xhrRequest(urlPositions, { headers: headersPositions });
 
       const bufferPositions = await responsePositions.arrayBuffer();
 
@@ -54,7 +54,7 @@ export class GltfDecoder implements GeometryDecoder {
       const lastColors = byteOffset * 4n + byteSize * 4n - 1n;
 
       const headersColors = { Range: `bytes=${firstColors}-${lastColors}` };
-      const responseColors = await fetch(urlColors, { headers: headersColors });
+      const responseColors = await this.xhrRequest(urlColors, { headers: headersColors });
       const bufferColors = await responseColors.arrayBuffer();
 
       buffer = appendBuffer(bufferPositions, bufferColors);
@@ -134,5 +134,9 @@ export class GltfDecoder implements GeometryDecoder {
 
   public get getUrl(): GetUrlFn {
     return this.context.getUrl;
+  }
+
+  private get xhrRequest(): XhrRequest {
+    return this.context.xhrRequest;
   }
 }

--- a/src/loading2/gltf-splats-decoder.ts
+++ b/src/loading2/gltf-splats-decoder.ts
@@ -1,5 +1,5 @@
 import { BufferAttribute, BufferGeometry } from 'three';
-import { GetUrlFn } from '../loading/types';
+import { GetUrlFn, XhrRequest } from '../loading/types';
 import { DecodedGeometry, GeometryDecoder } from './geometry-decoder';
 import { OctreeGeometryNode } from './octree-geometry-node';
 import { LoadingContext, Metadata } from './octree-loader';
@@ -103,7 +103,7 @@ export class GltfSplatDecoder implements GeometryDecoder {
         const firstByte = byteOffset * 4n * offsetMultiplier;
         const lastByte = firstByte + byteSize * 4n * offsetMultiplier - 1n;
         const headers: Record<string, string> = { Range: `bytes=${firstByte}-${lastByte}` };
-        const response = await fetch(url, { headers });
+        const response = await this.xhrRequest(url, { headers });
         return response.arrayBuffer();
       };
 
@@ -237,6 +237,10 @@ export class GltfSplatDecoder implements GeometryDecoder {
 
   private get getUrl(): GetUrlFn {
     return this.context.getUrl;
+  }
+
+  private get xhrRequest(): XhrRequest {
+    return this.context.xhrRequest;
   }
 
   private get harmonicsEnabled(): boolean {

--- a/src/loading2/load-octree.ts
+++ b/src/loading2/load-octree.ts
@@ -8,8 +8,8 @@ export async function loadOctree(
   loadHarmonics: boolean = false,
 ) {
   const trueUrl = await getUrl(url);
-  const loader = new OctreeLoader(getUrl, url, loadHarmonics);
-  const { geometry } = await loader.load(trueUrl, xhrRequest);
+  const loader = new OctreeLoader(getUrl, url, xhrRequest, loadHarmonics);
+  const { geometry } = await loader.load(trueUrl);
 
   return geometry;
 }


### PR DESCRIPTION
Currently the Potree2 decoder only uses the provided xhrRequest for getting the pointcloud's metadata.json file. 

The xhrRequest is not used for any of the other Potree2 requests (octree.bin, hierarchy.bin, etc), and therefore we cannot use authentication headers for Potree2 models. 

This PR adds the xhrRequest to the `LoadingContext`, so that the same xhrRequest can be used for all Potree2 requests. By default, the xhrRequest is the same as the original fetch, so there is no impact to existing functionality. 
