### PR TITLE
fix: cacheable potree2 octree node url

### DIFF
--- a/src/loading2/decoder.ts
+++ b/src/loading2/decoder.ts
@@ -41,8 +41,9 @@ export class Decoder implements GeometryDecoder {
       buffer = new ArrayBuffer(0);
       console.warn(`loaded node with 0 bytes: ${node.name}`);
     } else {
+      const urlOctreeCacheable = `${urlOctree}?range=${first}to${last}`;
       const headers = { Range: `bytes=${first}-${last}` };
-      const response = await fetch(urlOctree, { headers });
+      const response = await fetch(urlOctreeCacheable, { headers });
 
       buffer = await response.arrayBuffer();
     }


### PR DESCRIPTION
All Potree2 node requests are for an `octree.bin` file with the byteranges in the header, which means that they are not cacheable by the browser. 

This change is simple, it adds a url param with the requested byte range. This has no impact on the request, and allows the browser to cache the unique node URL. This change is great for performance, as it makes all Potree2 node data cacheable by the browser. 