### PR TITLE
feat: update pointcloud shaders to GLSL3

### DIFF
--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Camera,
   Color,
+  GLSL3,
   LessEqualDepth,
   Material,
   NearestFilter,
@@ -325,6 +326,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
   constructor(parameters: Partial<IPointCloudMaterialParameters> = {}) {
     super();
+
+    this.glslVersion = GLSL3;
 
     const tex = (this.visibleNodesTexture = generateDataTexture(2048, 1, new Color(0xffffff)));
     tex.minFilter = NearestFilter;

--- a/src/materials/shaders/pointcloud.frag
+++ b/src/materials/shaders/pointcloud.frag
@@ -1,10 +1,6 @@
 precision highp float;
 precision highp int;
 
-#if defined paraboloid_point_shape
-	#extension GL_EXT_frag_depth : enable
-#endif
-
 uniform mat4 viewMatrix;
 uniform vec3 cameraPosition;
 
@@ -45,35 +41,37 @@ uniform sampler2D depthMap;
 	uniform vec4 highlightedPointColor;
 #endif
 
-varying vec3 vColor;
+in vec3 vColor;
 
 #if !defined(color_type_point_index)
-	varying float vOpacity;
+	in float vOpacity;
 #endif
 
 #if defined(weighted_splats)
-	varying float vLinearDepth;
+	in float vLinearDepth;
 #endif
 
 #if !defined(paraboloid_point_shape) && defined(use_edl)
-	varying float vLogDepth;
+	in float vLogDepth;
 #endif
 
 #if defined(color_type_phong) && (MAX_POINT_LIGHTS > 0 || MAX_DIR_LIGHTS > 0) || defined(paraboloid_point_shape)
-	varying vec3 vViewPosition;
+	in vec3 vViewPosition;
 #endif
 
 #if defined(weighted_splats) || defined(paraboloid_point_shape)
-	varying float vRadius;
+	in float vRadius;
 #endif
 
 #if defined(color_type_phong) && (MAX_POINT_LIGHTS > 0 || MAX_DIR_LIGHTS > 0)
-	varying vec3 vNormal;
+	in vec3 vNormal;
 #endif
 
 #ifdef highlight_point
-	varying float vHighlight;
+	in float vHighlight;
 #endif
+
+out vec4 outFragColor;
 
 float specularStrength = 1.0;
 
@@ -109,16 +107,16 @@ void main() {
 
 	#if defined weighted_splats
 		vec2 uv = gl_FragCoord.xy / vec2(screenWidth, screenHeight);
-		float sDepth = texture2D(depthMap, uv).r;
+		float sDepth = texture(depthMap, uv).r;
 		if(vLinearDepth > sDepth + vRadius + blendDepthSupplement){
 			discard;
 		}
 	#endif
 
 	#if defined color_type_point_index
-		gl_FragColor = vec4(color, pcIndex / 255.0);
+		outFragColor = vec4(color, pcIndex / 255.0);
 	#else
-		gl_FragColor = vec4(color, vOpacity);
+		outFragColor = vec4(color, vOpacity);
 	#endif
 
 	#ifdef use_point_cloud_mixing
@@ -143,8 +141,8 @@ void main() {
 	#ifdef use_texture_blending
 		vec2 vUv = gl_FragCoord.xy / vec2(screenWidth, screenHeight);
 
-		vec4 tColor = texture2D(backgroundMap, vUv);
-		gl_FragColor = vec4(vOpacity * color, 1.) + vec4((1. - vOpacity) * tColor.rgb, 0.);
+		vec4 tColor = texture(backgroundMap, vUv);
+		outFragColor = vec4(vOpacity * color, 1.) + vec4((1. - vOpacity) * tColor.rgb, 0.);
 	#endif
 
 	#if defined(color_type_phong)
@@ -267,7 +265,7 @@ void main() {
 
 		#endif
 
-		gl_FragColor.xyz = gl_FragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient ) + totalSpecular;
+		outFragColor.xyz = outFragColor.xyz * ( emissive + totalDiffuse + ambientLightColor * ambient ) + totalSpecular;
 
 	#endif
 
@@ -280,8 +278,8 @@ void main() {
 		//float distance = length(2.0 * gl_PointCoord - 1.0);
 		//float w = exp( -(distance * distance) / blendHardness);
 
-		gl_FragColor.rgb = gl_FragColor.rgb * w;
-		gl_FragColor.a = w;
+		outFragColor.rgb = outFragColor.rgb * w;
+		outFragColor.a = w;
 	#endif
 
 	#if defined paraboloid_point_shape
@@ -293,26 +291,26 @@ void main() {
 		pos = pos / pos.w;
 		float expDepth = pos.z;
 		depth = (pos.z + 1.0) / 2.0;
-		gl_FragDepthEXT = depth;
+		gl_FragDepth = depth;
 
 		#if defined(color_type_depth)
-			gl_FragColor.r = linearDepth;
-			gl_FragColor.g = expDepth;
+			outFragColor.r = linearDepth;
+			outFragColor.g = expDepth;
 		#endif
 
 		#if defined(use_edl)
-			gl_FragColor.a = log2(linearDepth);
+			outFragColor.a = log2(linearDepth);
 		#endif
 
 	#else
 		#if defined(use_edl)
-			gl_FragColor.a = vLogDepth;
+			outFragColor.a = vLogDepth;
 		#endif
 	#endif
 
 	#ifdef highlight_point
 		if (vHighlight > 0.0) {
-			gl_FragColor = highlightedPointColor;
+			outFragColor = highlightedPointColor;
 		}
 	#endif
 }


### PR DESCRIPTION
Update pointcloud shaders to use GLSL3. This fixes the issue: https://github.com/pnext/three-loader/issues/191


Changes are minimal and include: 
- Set PointCloudMaterial.glslVersion = GLSL3.
- Update `attribute` and `varying` syntax
- Replace `gl_FragColor` with `out vec4 outFragColor`
- Replace `texture2D()` with `texture()`
- Remove extensions that are core in GLSL3 (`GL_EXT_frag_depth`)
 