### PR TITLE
fix: fix wepback sourcemap annotations breaking stuff

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,8 +3,10 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const webpack = require('webpack');
 const baseConfig = require('./webpack.config');
 
-module.exports = Object.assign(baseConfig, {
+module.exports = {
+  ...baseConfig,
   stats: 'normal',
+  devtool: 'source-map', // Use production-rated source maps tool. See https://webpack.js.org/configuration/devtool/
   plugins: [
     ...baseConfig.plugins,
     new webpack.DefinePlugin({
@@ -17,4 +19,4 @@ module.exports = Object.assign(baseConfig, {
     }),
     new BundleAnalyzerPlugin({ analyzerMode: 'static' }),
   ],
-});
+};


### PR DESCRIPTION
Change the devtool config in the prod config for one that is compatible with ok for a production build according to webpack doc [^1]. This fix an issue where application using webpack and using three loaders will produce incorrect bundles.

[^1]:https://webpack.js.org/configuration/devtool/