### PR TITLE
feat: reduce artifact size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+build/report.html

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "license": "MIT",
   "main": "build/potree.js",
   "typings": "build/declarations/index.d.ts",
+  "files": [
+    "build/**/*"
+  ],
   "scripts": {
     "clean": "rimraf build",
     "start": "webpack --mode development --watch --progress",


### PR DESCRIPTION
Add a "files" property to the package.json to on ship to npm what an application using this lib will actually need[^1]. Currently, we ship the whole repo which for the client of this lib to download many files they do nothing with[^2]
[^1]:https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files
[^2]:https://www.npmjs.com/package/@pnext/three-loader/v/0.5.6?activeTab=code