### PR TITLE
feat(GS): have a manual scale on top of the LOD scale of the splats

### DIFF
--- a/src/materials/shaders/splats.vert
+++ b/src/materials/shaders/splats.vert
@@ -272,7 +272,7 @@ void main() {
 
     if(adaptiveSize) {
         float lodSplatScale = clamp(getLOD( instaceRawPosition, int(vnStart), float(level) ) / maxDepth, 0., 1.);
-        renderScale = mix(maxSplatScale, 1., lodSplatScale);
+        renderScale = mix(maxSplatScale * splatScale, 1., lodSplatScale);
     }
 
     vRenderScale = renderScale;


### PR DESCRIPTION
Allow the user to modify the splats scale for the LODs, the final LOD will display the splats scaled to 1.